### PR TITLE
No fill-rule for Motion Path

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -205,15 +205,10 @@ The initial position and the initial direction for basic shapes are defined as f
 		defined with 0 degree.</dd>
 	</dl>
 	</dd>
-	<dt><dfn>path()</dfn> = path([ <<fill-rule>> ,]? <<string>>)</dt>
+	<dt><dfn>path()</dfn> = path(<<string>>)</dt>
 	<dd>The <<string>> represents an SVG Path data string.
 		The path data string must be conform to the grammar and parsing rules of SVG 1.1 [[!SVG11]].
 		The initial position is defined by the first “move to” argument in the path string. For the initial direction follow SVG 1.1 [[!SVG11]].
-
-		<<fill-rule>> - The filling rule used to determine the interior of the path.
-		See 'fill-rule' property in SVG for details. Possible values are ''nonzero'' 
-		or ''evenodd''.
-		Default value when omitted is ''nonzero''.
 	</dd>
 	<dt><<url>></dt>
 	<dd>References an SVG <a>shape element</a> and uses its geometry as path.

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -527,14 +527,10 @@ The initial position and the initial direction for basic shapes are defined as f
 		If there is no such unequal coordinate pair, the initial direction is 
 		defined with 0 degree.
      </dl>
-    <dt><dfn class="dfn-paneled css" data-dfn-for="offset-path" data-dfn-type="function" data-export="" id="funcdef-offset-path-path">path()</dfn> = path([ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-2/#typedef-fill-rule">&lt;fill-rule></a> ,]? <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#string-value">&lt;string></a>)
-    <dd>
-     The <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#string-value">&lt;string></a> represents an SVG Path data string.
+    <dt><dfn class="dfn-paneled css" data-dfn-for="offset-path" data-dfn-type="function" data-export="" id="funcdef-offset-path-path">path()</dfn> = path(<a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#string-value">&lt;string></a>)
+    <dd>The <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#string-value">&lt;string></a> represents an SVG Path data string.
 		The path data string must be conform to the grammar and parsing rules of SVG 1.1 <a data-link-type="biblio" href="#biblio-svg11">[SVG11]</a>.
 		The initial position is defined by the first “move to” argument in the path string. For the initial direction follow SVG 1.1 <a data-link-type="biblio" href="#biblio-svg11">[SVG11]</a>. 
-     <p><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-2/#typedef-fill-rule">&lt;fill-rule></a> - The filling rule used to determine the interior of the path.
-		See <a class="property" data-link-type="propdesc" href="https://drafts.fxtf.org/paint/#propdef-fill-rule">fill-rule</a> property in SVG for details. Possible values are <a class="css" data-link-type="maybe" href="https://drafts.fxtf.org/paint/#valdef-fill-rule-nonzero">nonzero</a> or <a class="css" data-link-type="maybe" href="https://drafts.fxtf.org/paint/#valdef-fill-rule-evenodd">evenodd</a>.
-		Default value when omitted is <a class="css" data-link-type="maybe" href="https://drafts.fxtf.org/paint/#valdef-fill-rule-nonzero">nonzero</a>.</p>
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value">&lt;url></a>
     <dd>References an SVG <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a> and uses its geometry as path.
 	See SVG 1.1 for more information about the initial position and initial direction <a data-link-type="biblio" href="#biblio-svg11">[SVG11]</a>. 
@@ -1246,11 +1242,6 @@ the element.</p>
      <li><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-polygon">polygon()</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[CSS-SHAPES]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.csswg.org/css-shapes-2/#typedef-fill-rule">&lt;fill-rule></a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[css-transforms-1]</a> defines the following terms:
     <ul>
      <li><a href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">local coordinate system</a>
@@ -1281,13 +1272,6 @@ the element.</p>
      <li><a href="https://drafts.csswg.org/css21/visuren.html#x43">stacking context</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[paint-3]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.fxtf.org/paint/#valdef-fill-rule-evenodd">evenodd</a>
-     <li><a href="https://drafts.fxtf.org/paint/#propdef-fill-rule">fill-rule</a>
-     <li><a href="https://drafts.fxtf.org/paint/#valdef-fill-rule-nonzero">nonzero</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[SVG2]</a> defines the following terms:
     <ul>
      <li><a href="https://svgwg.org/svg2-draft/struct.html#container-element">container element</a>
@@ -1315,8 +1299,6 @@ the element.</p>
    <dd>Bert Bos; et al. <a href="https://www.w3.org/TR/CSS2">Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/CSS2">https://www.w3.org/TR/CSS2</a>
    <dt id="biblio-css3val">[CSS3VAL]
    <dd>Tab Atkins Jr.; Elika Etemad. <a href="http://dev.w3.org/csswg/css-values/">CSS Values and Units Module Level 3</a>. 11 June 2015. CR. URL: <a href="http://dev.w3.org/csswg/css-values/">http://dev.w3.org/csswg/css-values/</a>
-   <dt id="biblio-paint-3">[PAINT-3]
-   <dd>CSS Fill and Stroke Module Level 3 URL: <a href="https://drafts.fxtf.org/paint/">https://drafts.fxtf.org/paint/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-svg11">[SVG11]


### PR DESCRIPTION
fill-rule has been removed from the path function, which is used by offset-path.

Fixes issue #20