### PR TITLE
[css-motion] Unbounded computed distance along <angle> paths

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -186,7 +186,7 @@ Values have the following meanings:
 
 		<dt><dfn>contain</dfn></dt>
 		<dd>
-			When the value of 'offset-distance' would select a point on the path 
+			When the absolute value of 'offset-distance' would select a point on the path 
 			which is outside the edge of the containing element, the value is instead clipped 
 			so that the selected point lies on the edge of the element.
 		</dd>
@@ -626,15 +626,15 @@ Omitted values are set to their initial values.
 <h3 id="offset-processing">Offset processing</h3>
 <h4 id="calculating-the-computed-distance-along-a-path">Calculating the computed distance along a path</h4>
 
-Processing the distance along a path operates differently depending upon whether
-the path is open or closed:
+Processing the distance along a path operates differently depending upon the nature of the path:
 
-*   References to <<angle>> lines are closed.
-*   All basic CSS shapes are closed. 
-*   Paths (including references to SVG Paths) are closed only if the final command 
-	in the path list is a closepath command ("z" or "Z").
-*   References to SVG circles, ellipses, images, polygons and rects are closed.
-*   References to SVG lines and polylines are open.
+*   References to <<angle>> paths with contain are unclosed intervals.
+*   References to <<angle>> paths without contain are unbounded rays.
+*   All basic CSS shapes are closed loops.
+*   Paths (including references to SVG Paths) are closed loops only if the final command 
+	in the path list is a closepath command ("z" or "Z"), otherwise they are unclosed intervals.
+*   References to SVG circles, ellipses, images, polygons and rects are closed loops.
+*   References to SVG lines and polylines are unclosed intervals.
 
 To determine the <dfn>computed distance</dfn> for a given <var>path</var> and <var>distance</var>:
 
@@ -650,10 +650,14 @@ To determine the <dfn>computed distance</dfn> for a given <var>path</var> and <v
     ::  Let <var>upper bound</var> be equal to 100%.
 
 3.  
-    :   If <var>path</var> is a closed path:
-    ::  Let <a>computed distance</a> be equal to <var>distance</var> modulus <var>upper bound</var>.
-    :   Otherwise:
+    :   If <var>path</var> is an unbounded ray:
+    ::  Let <a>computed distance</a> be equal to <var>distance</var>.
+    :   Otherwise if <var>path</var> is an <<angle>> path with contain:
+    ::  Let <a>computed distance</a> be equal to <var>distance</var>, clamped by <var>-upper bound</var> and <var>upper bound</var>.
+    :   If <var>path</var> is any other unclosed interval:
     ::  Let <a>computed distance</a> be equal to <var>distance</var> clamped by 0 and <var>upper bound</var>.
+    :   Otherwise <var>path</var> is a closed loop:
+    ::  Let <a>computed distance</a> be equal to <var>distance</var> modulus <var>upper bound</var>.
 
 </div>
 

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-22">22 September 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-26">26 September 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -504,7 +504,7 @@ and its ancestors have no transformation applied.</p>
 			Even if the offset given by <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> or <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#percentage-value">&lt;percentage></a> changes, 
 			the position of the element specified with <var>closest-side</var> is the same. </p>
       <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-contain">contain<a class="self-link" href="#offset-path-contain"></a></dfn>
-      <dd> When the value of <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> would select a point on the path 
+      <dd> When the absolute value of <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> would select a point on the path 
 			which is outside the edge of the containing element, the value is instead clipped 
 			so that the selected point lies on the edge of the element. 
       <div class="example" id="example-7002d3a2">
@@ -988,20 +988,21 @@ how to process an <a class="property" data-link-type="propdesc" href="#propdef-o
 Omitted values are set to their initial values.</p>
    <h3 class="heading settled" data-level="4.7" id="offset-processing"><span class="secno">4.7. </span><span class="content">Offset processing</span><a class="self-link" href="#offset-processing"></a></h3>
    <h4 class="heading settled" data-level="4.7.1" id="calculating-the-computed-distance-along-a-path"><span class="secno">4.7.1. </span><span class="content">Calculating the computed distance along a path</span><a class="self-link" href="#calculating-the-computed-distance-along-a-path"></a></h4>
-   <p>Processing the distance along a path operates differently depending upon whether
-the path is open or closed:</p>
+   <p>Processing the distance along a path operates differently depending upon the nature of the path:</p>
    <ul>
     <li data-md="">
-     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> lines are closed.</p>
+     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> paths with contain are unclosed intervals.</p>
     <li data-md="">
-     <p>All basic CSS shapes are closed.</p>
+     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> paths without contain are unbounded rays.</p>
     <li data-md="">
-     <p>Paths (including references to SVG Paths) are closed only if the final command
-in the path list is a closepath command ("z" or "Z").</p>
+     <p>All basic CSS shapes are closed loops.</p>
     <li data-md="">
-     <p>References to SVG circles, ellipses, images, polygons and rects are closed.</p>
+     <p>Paths (including references to SVG Paths) are closed loops only if the final command
+in the path list is a closepath command ("z" or "Z"), otherwise they are unclosed intervals.</p>
     <li data-md="">
-     <p>References to SVG lines and polylines are open.</p>
+     <p>References to SVG circles, ellipses, images, polygons and rects are closed loops.</p>
+    <li data-md="">
+     <p>References to SVG lines and polylines are unclosed intervals.</p>
    </ul>
    <p>To determine the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="computed-distance">computed distance</dfn> for a given <var>path</var> and <var>distance</var>:</p>
    <div class="switch">
@@ -1023,13 +1024,21 @@ sub-paths.</p>
      <li data-md="">
       <dl>
        <dt data-md="">
-        <p>If <var>path</var> is a closed path:</p>
+        <p>If <var>path</var> is an unbounded ray:</p>
        <dd data-md="">
-        <p>Let <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-1">computed distance</a> be equal to <var>distance</var> modulus <var>upper bound</var>.</p>
+        <p>Let <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-1">computed distance</a> be equal to <var>distance</var>.</p>
        <dt data-md="">
-        <p>Otherwise:</p>
+        <p>Otherwise if <var>path</var> is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> path with contain:</p>
        <dd data-md="">
-        <p>Let <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-2">computed distance</a> be equal to <var>distance</var> clamped by 0 and <var>upper bound</var>.</p>
+        <p>Let <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-2">computed distance</a> be equal to <var>distance</var>, clamped by <var>-upper bound</var> and <var>upper bound</var>.</p>
+       <dt data-md="">
+        <p>If <var>path</var> is any other unclosed interval:</p>
+       <dd data-md="">
+        <p>Let <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-3">computed distance</a> be equal to <var>distance</var> clamped by 0 and <var>upper bound</var>.</p>
+       <dt data-md="">
+        <p>Otherwise <var>path</var> is a closed loop:</p>
+       <dd data-md="">
+        <p>Let <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-4">computed distance</a> be equal to <var>distance</var> modulus <var>upper bound</var>.</p>
       </dl>
     </ol>
    </div>
@@ -1047,9 +1056,9 @@ sub-paths.</p>
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Determine the <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-3">computed distance</a> by invoking the process for <a href="#calculating-the-computed-distance-along-a-path"> Calculating the computed distance along a path</a> on <var>path</var> and <var>distance</var>.</p>
+          <p>Determine the <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-5">computed distance</a> by invoking the process for <a href="#calculating-the-computed-distance-along-a-path"> Calculating the computed distance along a path</a> on <var>path</var> and <var>distance</var>.</p>
          <li data-md="">
-          <p>Let <var>position</var> be the coordinate pair at <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-4">computed distance</a> along <var>path</var>.</p>
+          <p>Let <var>position</var> be the coordinate pair at <a data-link-type="dfn" href="#computed-distance" id="ref-for-computed-distance-6">computed distance</a> along <var>path</var>.</p>
          <li data-md="">
           <p>Create the supplemental transformation matrix <var>transform</var> to the local coordinate system of the element.</p>
          <li data-md="">
@@ -1501,8 +1510,8 @@ the element.</p>
   <aside class="dfn-panel" data-for="computed-distance">
    <b><a href="#computed-distance">#computed-distance</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-computed-distance-1">4.7.1. Calculating the computed distance along a path</a> <a href="#ref-for-computed-distance-2">(2)</a>
-    <li><a href="#ref-for-computed-distance-3">4.7.2. Calculating the path transform</a> <a href="#ref-for-computed-distance-4">(2)</a>
+    <li><a href="#ref-for-computed-distance-1">4.7.1. Calculating the computed distance along a path</a> <a href="#ref-for-computed-distance-2">(2)</a> <a href="#ref-for-computed-distance-3">(3)</a> <a href="#ref-for-computed-distance-4">(4)</a>
+    <li><a href="#ref-for-computed-distance-5">4.7.2. Calculating the path transform</a> <a href="#ref-for-computed-distance-6">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
Distance is not bounded for <angle> paths without contain. We do not clamp or mod.

We clamp for <angle> paths with contain, and the "lower bound" is the negative of "upper bound".

Resolves #35.