### PR TITLE
[css-motion] Computed value of distance is absolute value or %

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -280,7 +280,7 @@ Initial: 0
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <{defs}> element and all <a>graphics elements</a>
 Inherited: no
 Percentages: refer to the total path length
-Computed value: as specified
+Computed value: For <<length>> the absolute value, otherwise a percentage.
 Media: visual
 Animatable: yes
 </pre>
@@ -335,6 +335,7 @@ Initial: auto
 Media: visual
 Inherited: no
 Percentages: Refer to the size of containing block
+Computed value: For <<length>> the absolute value, otherwise a percentage.
 Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">position</a>
 </pre>
 Specifies the initial position of the path.
@@ -360,6 +361,7 @@ Initial: auto
 Media: visual
 Inherited: no
 Percentages: Relative to the width and the height of an element
+Computed value: For <<length>> the absolute value, otherwise a percentage.
 Animatable: as <<position>>
 </pre>
 

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-02">2 September 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-06">6 September 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -596,7 +596,7 @@ or is non-existent is ignored. No path and no stacking context are created.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>as specified
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -667,7 +667,7 @@ the initial position and the end position of the path.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>as specified
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -711,7 +711,7 @@ the initial position and the end position of the path.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>as specified
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -1344,7 +1344,7 @@ the element.</p>
       <td>visual
       <td>yes
       <td>per grammar
-      <td>as specified
+      <td>For &lt;length> the absolute value, otherwise a percentage.
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-position">offset-position</a>
       <td>auto | &lt;position>
@@ -1355,7 +1355,7 @@ the element.</p>
       <td>visual
       <td>as position
       <td>per grammar
-      <td>as specified
+      <td>For &lt;length> the absolute value, otherwise a percentage.
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-anchor">offset-anchor</a>
       <td>&lt;position>
@@ -1366,7 +1366,7 @@ the element.</p>
       <td>visual
       <td>as &lt;position>
       <td>per grammar
-      <td>as specified
+      <td>For &lt;length> the absolute value, otherwise a percentage.
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-rotation">offset-rotation</a>
       <td>[ auto | reverse ] &amp;&amp; &lt;angle>


### PR DESCRIPTION
The computed value is an absolute value or a percentage, not the
specified value (which may be 'auto' or use em, vh, etc.

Resolves #37