### PR TITLE
[css-motion] offset-position creates a stacking context

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -352,6 +352,10 @@ Values are defined as follows:
 </dd>
 </dl>
 
+A computed value of other than ''auto'' results in the creation of a <a spec="css21">stacking context</a> [[!CSS21]]
+the same way that CSS 'opacity' [[CSS3COLOR]] does for values other than ''1'',
+unless the element is an SVG element without an associated CSS layout box.
+
 <h3 id="offset-anchor-property">Define an anchor point: The 'offset-anchor' property</h3>
 <pre class='propdef'>
 Name: offset-anchor

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-13">13 September 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-09-22">22 September 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -310,7 +310,7 @@
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -688,6 +688,8 @@ the initial position and the end position of the path.</p>
 	of the initial position of the path from the top left corner of the containing block
 	that are computed as specified in CSS Backgrounds <a data-link-type="biblio" href="#biblio-css3-background">[CSS3-BACKGROUND]</a>. 
    </dl>
+   <p>A computed value of other than <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-1">auto</a> results in the creation of a <a data-link-type="dfn" href="https://drafts.csswg.org/css21/visuren.html#x43">stacking context</a> <a data-link-type="biblio" href="#biblio-css21">[CSS21]</a> the same way that CSS <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a> <a data-link-type="biblio" href="#biblio-css3color">[CSS3COLOR]</a> does for values other than <span class="css">1</span>,
+unless the element is an SVG element without an associated CSS layout box.</p>
    <h3 class="heading settled" data-level="4.4" id="offset-anchor-property"><span class="secno">4.4. </span><span class="content">Define an anchor point: The <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-1">offset-anchor</a> property</span><a class="self-link" href="#offset-anchor-property"></a></h3>
    <table class="def propdef" data-link-for-hint="offset-anchor">
     <tbody>
@@ -729,7 +731,7 @@ as the point that is moved along the path.</p>
    <dl>
     <dt><var>auto</var>
     <dd>Computes to the value from <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-2">offset-position</a>.
-	When <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-1">auto</a> is given to <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-2">offset-anchor</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-3">offset-position</a> behaves similar to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>. 
+	When <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-2">auto</a> is given to <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-2">offset-anchor</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-3">offset-position</a> behaves similar to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>. 
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
     <dd>
      <dl>
@@ -833,7 +835,7 @@ as the point that is moved along the path.</p>
 the angle of the direction 
 (i.e., directional tangent vector) of the <a data-link-type="dfn" href="#path" id="ref-for-path-5">path</a>. 
 If specified in combination with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added
-to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-2">auto</a>.
+to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-3">auto</a>.
     <dt><dfn class="dfn-paneled css" data-dfn-for="offset-rotation" data-dfn-type="value" data-export="" id="valdef-offset-rotation-reverse">reverse</dfn>
     <dd>
      Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-8">offset-distance</a> is animated) by
@@ -845,7 +847,7 @@ to the computed value of <a class="css" data-link-type="maybe" href="#valdef-off
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>
     <dd>Indicates that the element has a constant rotation transformation applied to it 
 by the specified rotation angle.
-See definitions of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-3">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-2">reverse</a> if specified in combination with 
+See definitions of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-4">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-2">reverse</a> if specified in combination with 
 either one of the keywords.
 For the purpose of this argument, <span class="css">0deg</span> points to the right side in the direction of 
 the positive y-axis, and positive angles represent clockwise rotation, 
@@ -866,7 +868,7 @@ The red dot in the middle of the shape indicates the origin of the shape.
      <figcaption>A black plane at different positions on a blue dotted path without 
 	rotation transforms.</figcaption>
     </div>
-    <p>If the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-3">offset-rotation</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-4">auto</a>, the shape’s point of origin is
+    <p>If the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-3">offset-rotation</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-5">auto</a>, the shape’s point of origin is
 placed at different positions along the path.
 The shape is rotated based on the gradient at the current position and faces 
 the direction of the path at this position.</p>
@@ -892,9 +894,9 @@ on the path.</p>
     </div>
    </div>
    <div class="example" id="example-96f2b703">
-    <a class="self-link" href="#example-96f2b703"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-5">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-4">reverse</a> works specified in combination 
+    <a class="self-link" href="#example-96f2b703"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-6">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-4">reverse</a> works specified in combination 
 with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
-The computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-6">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-5">reverse</a>. 
+The computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-7">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-5">reverse</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span> <span class="p">{</span>
     border<span class="o">-</span><span class="n">radius</span><span class="o">:</span> <span class="m">50%</span><span class="p">;</span>
@@ -941,11 +943,11 @@ The computed value of <a class="production css" data-link-type="type" href="http
 </pre>
     <div class="figure">
       <img alt="An image of example for offset-rotation" src="images/rotate_by_angle_with_auto.png" style="width: 250px; text-align: center"> 
-     <figcaption>The elements are rotated by the value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-7">auto</a> with 
+     <figcaption>The elements are rotated by the value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-8">auto</a> with 
 	a fixed amount of degree.</figcaption>
     </div>
    </div>
-   <p class="issue" id="issue-5d73326d"><a class="self-link" href="#issue-5d73326d"></a> More natural names requested for <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-8">auto</a> and <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-6">reverse</a>.</p>
+   <p class="issue" id="issue-5d73326d"><a class="self-link" href="#issue-5d73326d"></a> More natural names requested for <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-9">auto</a> and <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-6">reverse</a>.</p>
    <p>See the section <a href="#offset-processing">“Offset processing”</a> for
 how to process an <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-6">offset-rotation</a>.</p>
    <h3 class="heading settled" data-level="4.6" id="offset-shorthand"><span class="secno">4.6. </span><span class="content">Offset shorthand: The <a class="property" data-link-type="propdesc" href="#propdef-offset" id="ref-for-propdef-offset-1">offset</a> property</span><a class="self-link" href="#offset-shorthand"></a></h3>
@@ -1298,7 +1300,7 @@ the element.</p>
    <dt id="biblio-svg11">[SVG11]
    <dd>Erik Dahlström; et al. <a href="https://www.w3.org/TR/SVG11/">Scalable Vector Graphics (SVG) 1.1 (Second Edition)</a>. 16 August 2011. REC. URL: <a href="https://www.w3.org/TR/SVG11/">https://www.w3.org/TR/SVG11/</a>
    <dt id="biblio-svg2">[SVG2]
-   <dd>Nikos Andronikos; et al. <a href="https://svgwg.org/svg2-draft/">Scalable Vector Graphics (SVG) 2</a>. 15 September 2015. WD. URL: <a href="https://svgwg.org/svg2-draft/">https://svgwg.org/svg2-draft/</a>
+   <dd>Nikos Andronikos; et al. <a href="https://svgwg.org/svg2-draft/">Scalable Vector Graphics (SVG) 2</a>. 15 September 2016. CR. URL: <a href="https://svgwg.org/svg2-draft/">https://svgwg.org/svg2-draft/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -1479,8 +1481,9 @@ the element.</p>
   <aside class="dfn-panel" data-for="valdef-offset-rotation-auto">
    <b><a href="#valdef-offset-rotation-auto">#valdef-offset-rotation-auto</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-offset-rotation-auto-1">4.4. Define an anchor point: The offset-anchor property</a>
-    <li><a href="#ref-for-valdef-offset-rotation-auto-2">4.5. Rotation at point: The offset-rotation property</a> <a href="#ref-for-valdef-offset-rotation-auto-3">(2)</a> <a href="#ref-for-valdef-offset-rotation-auto-4">(3)</a> <a href="#ref-for-valdef-offset-rotation-auto-5">(4)</a> <a href="#ref-for-valdef-offset-rotation-auto-6">(5)</a> <a href="#ref-for-valdef-offset-rotation-auto-7">(6)</a> <a href="#ref-for-valdef-offset-rotation-auto-8">(7)</a>
+    <li><a href="#ref-for-valdef-offset-rotation-auto-1">4.3. Define the initial position of the path: The offset-position property</a>
+    <li><a href="#ref-for-valdef-offset-rotation-auto-2">4.4. Define an anchor point: The offset-anchor property</a>
+    <li><a href="#ref-for-valdef-offset-rotation-auto-3">4.5. Rotation at point: The offset-rotation property</a> <a href="#ref-for-valdef-offset-rotation-auto-4">(2)</a> <a href="#ref-for-valdef-offset-rotation-auto-5">(3)</a> <a href="#ref-for-valdef-offset-rotation-auto-6">(4)</a> <a href="#ref-for-valdef-offset-rotation-auto-7">(5)</a> <a href="#ref-for-valdef-offset-rotation-auto-8">(6)</a> <a href="#ref-for-valdef-offset-rotation-auto-9">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valdef-offset-rotation-reverse">


### PR DESCRIPTION
Even when offset-path is the initial value (none), offset-position
can be used to position elements.

Resolves #47