### PR TITLE
[css-motion] offset-path syntax using ray()

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -97,7 +97,7 @@ ISSUE: Add more details and examples.
 
 <pre class='propdef'>
 Name: offset-path
-Value: <<url>> | <<angle>> <<size>>? && contain? | [ <<basic-shape>> | <<path()>> ] || <<geometry-box>> | none
+Value: <<url>> | ray(<<angle>> && <<size>>? && contain?) | <<basic-shape>> || <<geometry-box>> | <<path()>> | none
 Initial: none
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <{defs}> element and all <a>graphics elements</a>
 Inherited: no
@@ -194,8 +194,8 @@ Values have the following meanings:
 		The first example shows that some parts of elements are outside of the path.
 		<pre class="lang-html">
 			&lt;body>
-				&lt;div style="offset-path: 45deg; offset-distance: 100%">&lt;/div>
-				&lt;div style="offset-path: 180deg; offset-distance: 100%">&lt;/div>
+				&lt;div style="offset-path: ray(45deg); offset-distance: 100%">&lt;/div>
+				&lt;div style="offset-path: ray(180deg); offset-distance: 100%">&lt;/div>
 			&lt;/body>
 		</pre>
 		<div class=figure> 
@@ -207,8 +207,8 @@ Values have the following meanings:
 		to avoid overflowing.
 		<pre class="lang-html">
 			&lt;body>
-				&lt;div style="offset-path: 45deg contain; offset-distance: 100%">&lt;/div>
-				&lt;div style="offset-path: 180deg contain; offset-distance: 100%">&lt;/div>
+				&lt;div style="offset-path: ray(45deg contain); offset-distance: 100%">&lt;/div>
+				&lt;div style="offset-path: ray(180deg contain); offset-distance: 100%">&lt;/div>
 			&lt;/body>
 		</pre>
 		<div class=figure>
@@ -306,15 +306,15 @@ This example shows a way to align elements within the polar coordinate system us
 	&lt;/body>
 	&lt;style>
 		#circle1 {
-			offset-path: 0deg;
+			offset-path: ray(0deg);
 			offset-distance: 50%;
 		}
 		#circle2 {
-			offset-path: 90deg;
+			offset-path: ray(90deg);
 			offset-distance: 20%;
 		}
 		#circle3 {
-			offset-path: 225deg;
+			offset-path: ray(225deg);
 			offset-distance: 100%;
 		}
 	&lt;/style>
@@ -417,22 +417,22 @@ This example shows an alignment of four elements with different anchor points.
 <pre class="lang-html">
 	&lt;style>
 		#item1 {
-			offset-path: 45deg;
+			offset-path: ray(45deg);
 			offset-distance: 100%;
 			offset-anchor: right top;
 		}
 		#item2 {
-			offset-path: 135deg;
+			offset-path: ray(135deg);
 			offset-distance: 100%;
 			offset-anchor: right bottom;
 			}
 		#item3 {
-			offset-path: 225deg;
+			offset-path: ray(225deg);
 			offset-distance: 100%;
 			offset-anchor: left bottom;
 		}
 		#item4 {
-			offset-path: 315deg;
+			offset-path: ray(315deg);
 			offset-distance: 100%;
 			offset-anchor: left top;
 		}
@@ -554,32 +554,32 @@ The computed value of <<angle>> is added to the computed value of ''auto'' or ''
 			border-radius: 50%;
 		}
 		#item1 {
-			offset-path: 0deg;
+			offset-path: ray(0deg);
 			offset-distance: 90%;
 			offset-rotate: auto 90deg;
 		}
 		#item2 {
-			offset-path: 45deg;
+			offset-path: ray(45deg);
 			offset-distance: 90%;
 			offset-rotate: auto 90deg;
 		}
 		#item3 {
-			offset-path: 135deg;
+			offset-path: ray(135deg);
 			offset-distance: 90%;
 			offset-rotate: auto -90deg;
 		}
 		#item4 {
-			offset-path: 180deg;
+			offset-path: ray(180deg);
 			offset-distance: 90%;
 			offset-rotate: auto -90deg;
 		}
 		#item5 {
-			offset-path: 225deg;
+			offset-path: ray(225deg);
 			offset-distance: 90%;
 			offset-rotate: auto -90deg;
 		}
 		#item6 {
-			offset-path: -45deg;
+			offset-path: ray(-45deg);
 			offset-distance: 90%;
 			offset-rotate: auto 90deg;
 		}

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -288,9 +288,9 @@
         </style>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-02">2 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-04">4 October 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -300,9 +300,8 @@
      <dt>Previous Versions:
      <dd><a href="https://www.w3.org/TR/2015/WD-motion-1-20150409/" rel="previous">https://www.w3.org/TR/2015/WD-motion-1-20150409/</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-fx@w3.org?subject=%5Bmotion%5D%20YOUR%20TOPIC%20HERE">public-fx@w3.org</a> with subject line “<kbd>[motion] <i data-lt="">… message topic …</i></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-fx/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-fx@w3.org?subject=%5Bmotion%5D%20YOUR%20TOPIC%20HERE">public-fx@w3.org</a> with subject line “<kbd>[motion] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-fx/" rel="discussion">archives</a>)</span>
      <dt>Issue Tracking:
-     <dd><a href="https://github.com/w3c/fxtf-drafts/issues/">GitHub</a>
      <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:dschulze@adobe.com">Dirk Schulze</a> (<span class="p-org org">Adobe Systems Inc.</span>)
@@ -311,7 +310,7 @@
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -418,7 +417,7 @@
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-offset-path">offset-path</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value">&lt;url></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> contain<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="function" href="#funcdef-offset-path-path" id="ref-for-funcdef-offset-path-path-4">&lt;path()></a> ] <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any">||</a> <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> none
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value">&lt;url></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> ray(<a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> contain<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a>) <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any">||</a> <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="function" href="#funcdef-offset-path-path" id="ref-for-funcdef-offset-path-path-4">&lt;path()></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> none
      <tr>
       <th>Initial:
       <td>none
@@ -507,23 +506,25 @@ and its ancestors have no transformation applied.</p>
       <dd> When the absolute value of <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> would select a point on the path 
 			which is outside the edge of the containing element, the value is instead clipped 
 			so that the selected point lies on the edge of the element. 
-      <div class="example" id="example-7002d3a2">
-       <a class="self-link" href="#example-7002d3a2"></a> Here are some examples.
+      <div class="example" id="example-62cc855c">
+       <a class="self-link" href="#example-62cc855c"></a> Here are some examples.
 		The first example shows that some parts of elements are outside of the path. 
-<pre class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: 45deg; offset-distance: 100%"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: 180deg; offset-distance: 100%"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span></pre>
+<pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(45deg); offset-distance: 100%"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(180deg); offset-distance: 100%"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">body</span><span class="p">></span>
+</pre>
        <div class="figure">
          <img alt="An image of elements positioned without contain" src="images/offset_distance_without_contain.png" style="width: 200px;"> 
         <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-2">offset-path</a> without <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a></figcaption>
        </div>
        <p>In the second example, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a> is given to the <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-3">offset-path</a> value of each element
 		to avoid overflowing.</p>
-<pre class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: 45deg contain; offset-distance: 100%"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: 180deg contain; offset-distance: 100%"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span></pre>
+<pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(45deg contain); offset-distance: 100%"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(180deg contain); offset-distance: 100%"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">body</span><span class="p">></span>
+</pre>
        <div class="figure">
          <img alt="An image of elements positioned with contain" src="images/offset_distance_with_contain.png" style="width: 200px;"> 
         <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-4">offset-path</a> with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a></figcaption>
@@ -615,27 +616,28 @@ the initial position and the end position of the <a data-link-type="dfn" href="#
     <p></p>
    </dl>
     See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-5">offset-distance</a>. 
-   <div class="example" id="example-ba4bde16">
-    <a class="self-link" href="#example-ba4bde16"></a> This example shows a way to align elements within the polar coordinate system using <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-5">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-6">offset-distance</a>. 
-<pre class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"circle1"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"circle2"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"circle3"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
+   <div class="example" id="example-c78615d8">
+    <a class="self-link" href="#example-c78615d8"></a> This example shows a way to align elements within the polar coordinate system using <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-5">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-6">offset-distance</a>. 
+<pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"circle1"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"circle2"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"circle3"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">body</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nn">#circle1</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">0</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">0</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">50%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#circle2</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">90</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">20%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#circle3</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">225</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">225</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
   <span class="p">}</span>
-<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span></pre>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
     <div class="figure">
       <img alt="An image of three elements positioned to polar coordinates" src="images/simple_offset_position.png" style="width: 300px;"> 
      <figcaption>An example of positioning element in polar coordinates</figcaption>
@@ -744,45 +746,47 @@ as the point that is moved along the <a data-link-type="dfn" href="#path" id="re
    </dl>
    <div class="example" id="example-ea8b7653">
     <a class="self-link" href="#example-ea8b7653"></a> The following explains how to set the anchor point of the element. 
-<pre class="lang-css highlight"><span></span><span class="nt">#plane </span><span class="p">{</span>
+<pre class="lang-css highlight"><span class="nt">#plane </span><span class="p">{</span>
   <span class="k">offset-anchor</span><span class="p">:</span> center<span class="p">;</span>
-<span class="p">}</span></pre>
+<span class="p">}</span>
+</pre>
     <p>The red dot in the middle of the shape indicates the anchor point of the shape.</p>
     <div class="figure">
       <img alt="Shape with its anchor point" height="140" src="images/plane.svg" width="160"> 
      <figcaption>A red dot in the middle of a plane shape indicates the shape’s anchor point.</figcaption>
     </div>
    </div>
-   <div class="example" id="example-2c688f8a">
-    <a class="self-link" href="#example-2c688f8a"></a> This example shows an alignment of four elements with different anchor points. 
-<pre class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+   <div class="example" id="example-bf960337">
+    <a class="self-link" href="#example-bf960337"></a> This example shows an alignment of four elements with different anchor points. 
+<pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nn">#item1</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">45</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">45</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> <span class="nb">right</span> <span class="nb">top</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> right top<span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item2</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">135</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">135</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> <span class="nb">right</span> <span class="nb">bottom</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> right bottom<span class="p">;</span>
     <span class="p">}</span>
   <span class="nn">#item3</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">225</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">225</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> <span class="nb">left</span> <span class="nb">bottom</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> left bottom<span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item4</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">315</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">315</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> <span class="nb">left</span> <span class="nb">top</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> left top<span class="p">;</span>
   <span class="p">}</span>
-<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item1"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item2"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item3"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item4"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span></pre>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item1"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item2"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item3"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item4"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">body</span><span class="p">></span>
+</pre>
     <div class="figure">
       <img alt="An example of offset-anchor" src="images/offset_anchor.png" style="width: 300px;"> 
      <figcaption>An example of <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-3">offset-anchor</a></figcaption>
@@ -888,53 +892,54 @@ on the path.</p>
 	rotated by a fixed amount of degree.</figcaption>
     </div>
    </div>
-   <div class="example" id="example-96f2b703">
-    <a class="self-link" href="#example-96f2b703"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-6">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-4">reverse</a> works specified in combination 
+   <div class="example" id="example-7829c6a4">
+    <a class="self-link" href="#example-7829c6a4"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-6">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-4">reverse</a> works specified in combination 
 with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
 The computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-7">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-5">reverse</a>. 
-<pre class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+<pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span> <span class="p">{</span>
-    <span class="nb">border</span><span class="o">-</span><span class="n">radius</span><span class="o">:</span> <span class="m">50%</span><span class="p">;</span>
+    border<span class="o">-</span><span class="n">radius</span><span class="o">:</span> <span class="m">50%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item1</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">0</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">0</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">90%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> <span class="nb">auto</span> <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> auto <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item2</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">45</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">45</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">90%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> <span class="nb">auto</span> <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> auto <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item3</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">135</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">135</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">90%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> <span class="nb">auto</span> <span class="m">-90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> auto <span class="m">-90</span><span class="n">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item4</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">180</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">180</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">90%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> <span class="nb">auto</span> <span class="m">-90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> auto <span class="m">-90</span><span class="n">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item5</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">225</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">225</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">90%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> <span class="nb">auto</span> <span class="m">-90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> auto <span class="m">-90</span><span class="n">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item6</span> <span class="p">{</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="m">-45</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">-45</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">90%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> <span class="nb">auto</span> <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> auto <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
   <span class="p">}</span>
-<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item1"</span><span class="p">></span>1<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item2"</span><span class="p">></span>2<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item3"</span><span class="p">></span>3<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item4"</span><span class="p">></span>4<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item5"</span><span class="p">></span>5<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item6"</span><span class="p">></span>6<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span></pre>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item1"</span><span class="p">></span>1<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item2"</span><span class="p">></span>2<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item3"</span><span class="p">></span>3<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item4"</span><span class="p">></span>4<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item5"</span><span class="p">></span>5<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"item6"</span><span class="p">></span>6<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">body</span><span class="p">></span>
+</pre>
     <div class="figure">
       <img alt="An image of example for offset-rotation" src="images/rotate_by_angle_with_auto.png" style="width: 250px; text-align: center"> 
      <figcaption>The elements are rotated by the value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-8">auto</a> with 
@@ -1100,13 +1105,13 @@ the element.</p>
     is defined for three conformance classes: </p>
   <dl>
    <dt>style sheet 
-   <dd>A <a href="http://www.w3.org/TR/CSS21/conform.html#style-sheet">CSS
+   <dd>A <a href="https://www.w3.org/TR/CSS21/conform.html#style-sheet">CSS
             style sheet</a>. 
    <dt>renderer 
-   <dd>A <a href="http://www.w3.org/TR/CSS21/conform.html#user-agent">UA</a> that interprets the semantics of a style sheet and renders
+   <dd>A <a href="https://www.w3.org/TR/CSS21/conform.html#user-agent">UA</a> that interprets the semantics of a style sheet and renders
             documents that use them. 
    <dt>authoring tool 
-   <dd>A <a href="http://www.w3.org/TR/CSS21/conform.html#user-agent">UA</a> that writes a style sheet. 
+   <dd>A <a href="https://www.w3.org/TR/CSS21/conform.html#user-agent">UA</a> that writes a style sheet. 
   </dl>
   <p>A style sheet is conformant to this specification
     if all of its statements that use syntax defined in this module are valid
@@ -1127,7 +1132,7 @@ the element.</p>
     as described in this module. </p>
   <h3 class="no-ref heading settled" id="partial"><span class="content"> Partial implementations</span><a class="self-link" href="#partial"></a></h3>
   <p>So that authors can exploit the forward-compatible parsing rules to
-    assign fallback values, CSS renderers <strong>must</strong> treat as invalid (and <a href="http://www.w3.org/TR/CSS21/conform.html#ignore">ignore
+    assign fallback values, CSS renderers <strong>must</strong> treat as invalid (and <a href="https://www.w3.org/TR/CSS21/conform.html#ignore">ignore
     as appropriate</a>) any at-rules, properties, property values, keywords,
     and other syntactic constructs for which they have no usable level of
     support. In particular, user agents <strong>must not</strong> selectively
@@ -1137,7 +1142,7 @@ the element.</p>
     be ignored.</p>
   <h3 class="no-ref heading settled" id="experimental"><span class="content"> Experimental implementations</span><a class="self-link" href="#experimental"></a></h3>
   <p>To avoid clashes with future CSS features, the CSS2.1 specification
-    reserves a <a href="http://www.w3.org/TR/CSS21/syndata.html#vendor-keywords">prefixed
+    reserves a <a href="https://www.w3.org/TR/CSS21/syndata.html#vendor-keywords">prefixed
     syntax</a> for proprietary and experimental extensions to CSS. </p>
   <p>Prior to a specification reaching the Candidate Recommendation stage
     in the W3C process, all implementations of a CSS feature are considered
@@ -1159,8 +1164,8 @@ the element.</p>
     Working Group. </p>
   <p>
    Further information on submitting testcases and implementation reports
-    can be found from on the CSS Working Group’s website at <a href="http://www.w3.org/Style/CSS/Test/">http://www.w3.org/Style/CSS/Test/</a>.
-    Questions should be directed to the <a href="http://lists.w3.org/Archives/Public/public-css-testsuite">public-css-testsuite@w3.org</a> mailing list. 
+    can be found from on the CSS Working Group’s website at <a href="https://www.w3.org/Style/CSS/Test/">https://www.w3.org/Style/CSS/Test/</a>.
+    Questions should be directed to the <a href="https://lists.w3.org/Archives/Public/public-css-testsuite">public-css-testsuite@w3.org</a> mailing list. 
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
   </p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
@@ -1188,16 +1193,6 @@ the element.</p>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
-   <li>
-    <a data-link-type="biblio">[SVG11]</a> defines the following terms:
-    <ul>
-     <li><a href="https://www.w3.org/TR/SVG11/struct.html#DefsElement">defs</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[SVG2]</a> defines the following terms:
-    <ul>
-     <li><a href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a>
-    </ul>
    <li>
     <a data-link-type="biblio">[css-backgrounds-3]</a> defines the following terms:
     <ul>
@@ -1275,10 +1270,16 @@ the element.</p>
      <li><a href="https://drafts.csswg.org/css21/visuren.html#x43">stacking context</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[SVG11]</a> defines the following terms:
+    <ul>
+     <li><a href="https://www.w3.org/TR/SVG11/struct.html#DefsElement">defs</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[SVG2]</a> defines the following terms:
     <ul>
      <li><a href="https://svgwg.org/svg2-draft/struct.html#container-element">container element</a>
      <li><a href="https://svgwg.org/svg2-draft/struct.html#graphics-element">graphics element</a>
+     <li><a href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -1307,7 +1308,7 @@ the element.</p>
    <dt id="biblio-svg11">[SVG11]
    <dd>Erik Dahlström; et al. <a href="https://www.w3.org/TR/SVG11/">Scalable Vector Graphics (SVG) 1.1 (Second Edition)</a>. 16 August 2011. REC. URL: <a href="https://www.w3.org/TR/SVG11/">https://www.w3.org/TR/SVG11/</a>
    <dt id="biblio-svg2">[SVG2]
-   <dd>Nikos Andronikos; et al. <a href="https://svgwg.org/svg2-draft/">Scalable Vector Graphics (SVG) 2</a>. 15 September 2015. WD. URL: <a href="https://svgwg.org/svg2-draft/">https://svgwg.org/svg2-draft/</a>
+   <dd>Nikos Andronikos; et al. <a href="https://svgwg.org/svg2-draft/">Scalable Vector Graphics (SVG) 2</a>. 15 September 2016. CR. URL: <a href="https://svgwg.org/svg2-draft/">https://svgwg.org/svg2-draft/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -1336,7 +1337,7 @@ the element.</p>
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-path">offset-path</a>
-      <td>&lt;url> | &lt;angle> &lt;size>? &amp;&amp; contain? | [ &lt;basic-shape> | &lt;path()> ] || &lt;geometry-box> | none
+      <td>&lt;url> | ray(&lt;angle> &amp;&amp; &lt;size>? &amp;&amp; contain?) | &lt;basic-shape> || &lt;geometry-box> | &lt;path()> | none
       <td>none
       <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
       <td>no


### PR DESCRIPTION
Angle paths are now specified using ray functions, instead
of simple sequences of CSS values. This especially improves
readability when shorthands are used. (Note that offset-rotation
may also be an angle.)

Discussed in #42 and at TPAC.

geometry-box may not be used with a path.
