### PR TITLE
[css-motion] offset shorthand may be position / anchor

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -631,7 +631,7 @@ how to process an 'offset-rotation'.
 <h3 id="offset-shorthand">Offset shorthand: The 'offset' property</h3>
 <pre class='propdef'>
 	Name: offset
-	Value: &lt;'offset-path'> && &lt;'offset-distance'> && &lt;'offset-position'> && &lt;'offset-anchor'> && &lt;'offset-rotation'>
+	Value: [ <<offset-position>>? [ <<offset-path>> [ <<offset-distance>> || <<offset-rotation>> ]? ]? ]! <br> [ / <<offset-anchor>> ]?
 	Initial: see individual properties
 	Applies to: All elements. In SVG, it applies to <a href="">container elements</a> excluding the <{defs}> element and all <a>graphics elements</a>
 	Inherited: no
@@ -641,8 +641,7 @@ how to process an 'offset-rotation'.
 	Animatable: see individual properties
 </pre>
 
-This is a shorthand property for setting 'offset-path', 'offset-distance', 
-'offset-position', 'offset-anchor' and 'offset-rotation'.
+This is a shorthand property for setting 'offset-position', 'offset-path', 'offset-distance', 'offset-rotation' and 'offset-anchor'.
 Omitted values are set to their initial values.
 
 <h3 id="offset-processing">Offset processing</h3>

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -978,7 +978,7 @@ how to process an <a class="property" data-link-type="propdesc" href="#propdef-o
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-offset">offset</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod">&lt;<a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-7">offset-path</a>> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> &lt;<a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-10">offset-distance</a>> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> &lt;<a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-4">offset-position</a>> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> &lt;<a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-4">offset-anchor</a>> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> &lt;<a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-7">offset-rotation</a>>
+      <td class="prod">[ <a class="production css" data-link-type="type">&lt;offset-position></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> [ <a class="production css" data-link-type="type">&lt;offset-path></a> [ <a class="production css" data-link-type="type">&lt;offset-distance></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any">||</a> <a class="production css" data-link-type="type">&lt;offset-rotation></a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-req">!</a> <br> [ / <a class="production css" data-link-type="type">&lt;offset-anchor></a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a>
      <tr>
       <th>Initial:
       <td>see individual properties
@@ -1004,7 +1004,7 @@ how to process an <a class="property" data-link-type="propdesc" href="#propdef-o
       <th>Animatable:
       <td>see individual properties
    </table>
-   <p>This is a shorthand property for setting <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-8">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-11">offset-distance</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-5">offset-position</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-5">offset-anchor</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-8">offset-rotation</a>.
+   <p>This is a shorthand property for setting <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-4">offset-position</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-7">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-10">offset-distance</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-7">offset-rotation</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-4">offset-anchor</a>.
 Omitted values are set to their initial values.</p>
    <h3 class="heading settled" data-level="4.7" id="offset-processing"><span class="secno">4.7. </span><span class="content">Offset processing</span><a class="self-link" href="#offset-processing"></a></h3>
    <h4 class="heading settled" data-level="4.7.1" id="calculating-the-computed-distance-along-a-path"><span class="secno">4.7.1. </span><span class="content">Calculating the computed distance along a path</span><a class="self-link" href="#calculating-the-computed-distance-along-a-path"></a></h4>
@@ -1068,7 +1068,7 @@ sub-paths.</p>
      <li data-md="">
       <p>Let <var>path</var> be the geometry of the closed line segment, specified basic shape, path or SVG <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a> reference.</p>
      <li data-md="">
-      <p>Let <var>distance</var> be the computed value of <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-12">offset-distance</a>.</p>
+      <p>Let <var>distance</var> be the computed value of <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-11">offset-distance</a>.</p>
      <li data-md="">
       <dl>
        <dt data-md="">
@@ -1084,7 +1084,7 @@ sub-paths.</p>
          <li data-md="">
           <p>Translate <var>transform</var> by <var>position</var>.</p>
          <li data-md="">
-          <p>Let <var>rotate</var> be the computed value of <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-9">offset-rotation</a>.</p>
+          <p>Let <var>rotate</var> be the computed value of <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-8">offset-rotation</a>.</p>
          <li data-md="">
           <p>Post-multiply the rotation <var>rotate</var> to <var>transform</var>.</p>
          <li data-md="">
@@ -1273,6 +1273,7 @@ the element.</p>
    <li>
     <a data-link-type="biblio">[CSS3VAL]</a> defines the following terms:
     <ul>
+     <li><a href="https://drafts.csswg.org/css-values-4/#mult-req">!</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">&lt;length-percentage></a>
      <li><a href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a>
@@ -1405,7 +1406,7 @@ the element.</p>
       <td>as specified
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset">offset</a>
-      <td>&lt;offset-path> &amp;&amp; &lt;offset-distance> &amp;&amp; &lt;offset-position> &amp;&amp; &lt;offset-anchor> &amp;&amp; &lt;offset-rotation>
+      <td>[ &lt;offset-position>? [ &lt;offset-path> [ &lt;offset-distance> || &lt;offset-rotation> ]? ]? ]!  [ / &lt;offset-anchor> ]?
       <td>see individual properties
       <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
       <td>no
@@ -1428,7 +1429,7 @@ the element.</p>
    <ul>
     <li><a href="#ref-for-propdef-offset-path-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-path-2">(2)</a> <a href="#ref-for-propdef-offset-path-3">(3)</a> <a href="#ref-for-propdef-offset-path-4">(4)</a>
     <li><a href="#ref-for-propdef-offset-path-5">4.2. Position on the path: The offset-distance property</a> <a href="#ref-for-propdef-offset-path-6">(2)</a>
-    <li><a href="#ref-for-propdef-offset-path-7">4.6. Offset shorthand: The offset property</a> <a href="#ref-for-propdef-offset-path-8">(2)</a>
+    <li><a href="#ref-for-propdef-offset-path-7">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="path">
@@ -1460,8 +1461,8 @@ the element.</p>
     <li><a href="#ref-for-propdef-offset-distance-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-distance-2">(2)</a> <a href="#ref-for-propdef-offset-distance-3">(3)</a> <a href="#ref-for-propdef-offset-distance-4">(4)</a>
     <li><a href="#ref-for-propdef-offset-distance-5">4.2. Position on the path: The offset-distance property</a> <a href="#ref-for-propdef-offset-distance-6">(2)</a> <a href="#ref-for-propdef-offset-distance-7">(3)</a>
     <li><a href="#ref-for-propdef-offset-distance-8">4.5. Rotation at point: The offset-rotation property</a> <a href="#ref-for-propdef-offset-distance-9">(2)</a>
-    <li><a href="#ref-for-propdef-offset-distance-10">4.6. Offset shorthand: The offset property</a> <a href="#ref-for-propdef-offset-distance-11">(2)</a>
-    <li><a href="#ref-for-propdef-offset-distance-12">4.7.2. Calculating the path transform</a>
+    <li><a href="#ref-for-propdef-offset-distance-10">4.6. Offset shorthand: The offset property</a>
+    <li><a href="#ref-for-propdef-offset-distance-11">4.7.2. Calculating the path transform</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-offset-position">
@@ -1469,22 +1470,22 @@ the element.</p>
    <ul>
     <li><a href="#ref-for-propdef-offset-position-1">4.3. Define the starting point of the path: The offset-position property</a>
     <li><a href="#ref-for-propdef-offset-position-2">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-propdef-offset-position-3">(2)</a>
-    <li><a href="#ref-for-propdef-offset-position-4">4.6. Offset shorthand: The offset property</a> <a href="#ref-for-propdef-offset-position-5">(2)</a>
+    <li><a href="#ref-for-propdef-offset-position-4">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-offset-anchor">
    <b><a href="#propdef-offset-anchor">#propdef-offset-anchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-anchor-1">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-propdef-offset-anchor-2">(2)</a> <a href="#ref-for-propdef-offset-anchor-3">(3)</a>
-    <li><a href="#ref-for-propdef-offset-anchor-4">4.6. Offset shorthand: The offset property</a> <a href="#ref-for-propdef-offset-anchor-5">(2)</a>
+    <li><a href="#ref-for-propdef-offset-anchor-4">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-offset-rotation">
    <b><a href="#propdef-offset-rotation">#propdef-offset-rotation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-rotation-1">4.5. Rotation at point: The offset-rotation property</a> <a href="#ref-for-propdef-offset-rotation-2">(2)</a> <a href="#ref-for-propdef-offset-rotation-3">(3)</a> <a href="#ref-for-propdef-offset-rotation-4">(4)</a> <a href="#ref-for-propdef-offset-rotation-5">(5)</a> <a href="#ref-for-propdef-offset-rotation-6">(6)</a>
-    <li><a href="#ref-for-propdef-offset-rotation-7">4.6. Offset shorthand: The offset property</a> <a href="#ref-for-propdef-offset-rotation-8">(2)</a>
-    <li><a href="#ref-for-propdef-offset-rotation-9">4.7.2. Calculating the path transform</a>
+    <li><a href="#ref-for-propdef-offset-rotation-7">4.6. Offset shorthand: The offset property</a>
+    <li><a href="#ref-for-propdef-offset-rotation-8">4.7.2. Calculating the path transform</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valdef-offset-rotation-auto">


### PR DESCRIPTION
The properties must appear in specific order:
position path distance rotation / anchor
https://logs.csswg.org/irc.w3.org/css/2016-09-20/#e724237

There is one exception: distance and rotation may appear in either order.

The offset shorthand may simply contain a position.
https://logs.csswg.org/irc.w3.org/css/2016-09-20/#e724174

If offset-path is omitted, offset-distance and offset-rotation are not permitted.

The ambiguities in the original shorthand syntax are avoided:
- offset-distance is ambiguous with a position
  offset-path always appears between offset-position and offset-distance.
  / always appears between offset-distance and offset-anchor.
- multiple properties have the value auto
  offset-path must appear between offset-position and offset-rotation, if offset-position is auto.
  / always appears before offset-anchor.
- multiple properties have position
  / always appears before offset-anchor.
- consecutive positions are ambiguous
  / always appears before offset-anchor.
- multiple properties have angle
  offset-path will use ray() syntax for angle paths.
  https://logs.csswg.org/irc.w3.org/css/2016-09-20/#e724197

Resolves #42 and #24
