### PR TITLE
[motion] Editorial improvements to offset-distance

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -284,17 +284,17 @@ Media: visual
 Animatable: yes
 </pre>
 
-Describes the position of the element along the specified <a>path</a>.
+Specifies the position of the element as a distance along the <a>path</a> given by 'offset-path'.
 
 <dl dfn-for="offset-distance" dfn-type="value">
 <dt><<length-percentage>></dt>
-<dd>The distance from the initial position of the shape or <a>path</a> to the position 
-of the element.
+<dd>Specifies the distance from the initial position of the <a>path</a> to the position of the box’s anchor point.
 
-Percentages are relative to the length of the <a>path</a> - that is the distance between 
+Percentages are relative to the length of the <a>path</a>--
+that is, the distance between 
 the initial position and the end position of the <a>path</a>.</dd>
 </dl>
-See the section <a href="#offset-processing">“Offset processing”</a> for how to process an 'offset-distance'.
+See [[#offset-processing]] for how to process an 'offset-distance'.
 
 <div class='example'>
 This example shows a way to align elements within the polar coordinate system using 'offset-path', 'offset-distance'.


### PR DESCRIPTION
* Clarify property description and cross-link to 'offset-path' which it references.
* Use a more precise description for the <<length-percentage>> value. TODO: The word "anchor point" should later be hyperlinked to a <dfn> instance under 'offset-anchor'.
* Use em-dash instead of hyphen, per English typographic rules.
* Use Bikeshed cross-reference syntax.