### PR TITLE
[motion] Prevent accidental rotation in examples

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -159,7 +159,7 @@ Values have the following meanings:
 			If omitted it defaults to <var>closest-side</var>.
 
 			<dl>
-				<dt><dfn>closet-side</dfn></dt>
+				<dt><dfn>closest-side</dfn></dt>
 				<dd>The distance is measured between the initial position and the closest side
 				of the box from it.</dd>
 
@@ -194,8 +194,8 @@ Values have the following meanings:
 		The first example shows that some parts of elements are outside of the path.
 		<pre class="lang-html">
 			&lt;body>
-				&lt;div style="offset-path: ray(45deg); offset-distance: 100%">&lt;/div>
-				&lt;div style="offset-path: ray(180deg); offset-distance: 100%">&lt;/div>
+				&lt;div style="offset-path: ray(45deg); offset-distance: 100%; offset-rotation: 0deg">&lt;/div>
+				&lt;div style="offset-path: ray(180deg); offset-distance: 100%; offset-rotation: 0deg">&lt;/div>
 			&lt;/body>
 		</pre>
 		<div class=figure> 
@@ -207,8 +207,8 @@ Values have the following meanings:
 		to avoid overflowing.
 		<pre class="lang-html">
 			&lt;body>
-				&lt;div style="offset-path: ray(45deg contain); offset-distance: 100%">&lt;/div>
-				&lt;div style="offset-path: ray(180deg contain); offset-distance: 100%">&lt;/div>
+				&lt;div style="offset-path: ray(45deg contain); offset-distance: 100%; offset-rotation: 0deg">&lt;/div>
+				&lt;div style="offset-path: ray(180deg contain); offset-distance: 100%; offset-rotation: 0deg">&lt;/div>
 			&lt;/body>
 		</pre>
 		<div class=figure>
@@ -419,21 +419,25 @@ This example shows an alignment of four elements with different anchor points.
 		#item1 {
 			offset-path: ray(45deg);
 			offset-distance: 100%;
+			offset-rotation: 0deg;
 			offset-anchor: right top;
 		}
 		#item2 {
 			offset-path: ray(135deg);
 			offset-distance: 100%;
+			offset-rotation: 0deg;
 			offset-anchor: right bottom;
 			}
 		#item3 {
 			offset-path: ray(225deg);
 			offset-distance: 100%;
+			offset-rotation: 0deg;
 			offset-anchor: left bottom;
 		}
 		#item4 {
 			offset-path: ray(315deg);
 			offset-distance: 100%;
+			offset-rotation: 0deg;
 			offset-anchor: left top;
 		}
 	&lt;/style>

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-01">1 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-08">8 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -486,7 +486,7 @@ and its ancestors have no transformation applied.</p>
        <p> <b>&lt;size></b> = [ closest-side | closest-corner | farthest-side | farthest-corner ]</p>
        <p>If omitted it defaults to <var>closest-side</var>.</p>
        <dl>
-        <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-closet-side">closet-side<a class="self-link" href="#offset-path-closet-side"></a></dfn>
+        <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-closest-side">closest-side<a class="self-link" href="#offset-path-closest-side"></a></dfn>
         <dd>The distance is measured between the initial position and the closest side
 				of the box from it.
         <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-closest-corner">closest-corner<a class="self-link" href="#offset-path-closest-corner"></a></dfn>
@@ -508,12 +508,12 @@ and its ancestors have no transformation applied.</p>
       <dd> When the absolute value of <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> would select a point on the path 
 			which is outside the edge of the containing element, the value is instead clipped 
 			so that the selected point lies on the edge of the element. 
-      <div class="example" id="example-62cc855c">
-       <a class="self-link" href="#example-62cc855c"></a> Here are some examples.
+      <div class="example" id="example-0374b581">
+       <a class="self-link" href="#example-0374b581"></a> Here are some examples.
 		The first example shows that some parts of elements are outside of the path. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(45deg); offset-distance: 100%"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(180deg); offset-distance: 100%"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(45deg); offset-distance: 100%; offset-rotation: 0deg"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(180deg); offset-distance: 100%; offset-rotation: 0deg"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
 <span class="p">&lt;</span><span class="p">/</span><span class="nt">body</span><span class="p">></span>
 </pre>
        <div class="figure">
@@ -523,8 +523,8 @@ and its ancestors have no transformation applied.</p>
        <p>In the second example, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a> is given to the <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-3">offset-path</a> value of each element
 		to avoid overflowing.</p>
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(45deg contain); offset-distance: 100%"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(180deg contain); offset-distance: 100%"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(45deg contain); offset-distance: 100%; offset-rotation: 0deg"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: ray(180deg contain); offset-distance: 100%; offset-rotation: 0deg"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
 <span class="p">&lt;</span><span class="p">/</span><span class="nt">body</span><span class="p">></span>
 </pre>
        <div class="figure">
@@ -758,27 +758,31 @@ as the point that is moved along the <a data-link-type="dfn" href="#path" id="re
      <figcaption>A red dot in the middle of a plane shape indicates the shape’s anchor point.</figcaption>
     </div>
    </div>
-   <div class="example" id="example-bf960337">
-    <a class="self-link" href="#example-bf960337"></a> This example shows an alignment of four elements with different anchor points. 
+   <div class="example" id="example-d2765a98">
+    <a class="self-link" href="#example-d2765a98"></a> This example shows an alignment of four elements with different anchor points. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nn">#item1</span> <span class="p">{</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">45</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotation</span><span class="o">:</span> <span class="m">0</span><span class="n">deg</span><span class="p">;</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> right top<span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item2</span> <span class="p">{</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">135</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotation</span><span class="o">:</span> <span class="m">0</span><span class="n">deg</span><span class="p">;</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> right bottom<span class="p">;</span>
     <span class="p">}</span>
   <span class="nn">#item3</span> <span class="p">{</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">225</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotation</span><span class="o">:</span> <span class="m">0</span><span class="n">deg</span><span class="p">;</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> left bottom<span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item4</span> <span class="p">{</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">315</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotation</span><span class="o">:</span> <span class="m">0</span><span class="n">deg</span><span class="p">;</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">anchor</span><span class="o">:</span> left top<span class="p">;</span>
   <span class="p">}</span>
 <span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
@@ -1168,7 +1172,7 @@ the element.</p>
   <ul class="index">
    <li><a href="#valdef-offset-rotation-auto">auto</a><span>, in §4.5</span>
    <li><a href="#offset-path-closest-corner">closest-corner</a><span>, in §4.1</span>
-   <li><a href="#offset-path-closet-side">closet-side</a><span>, in §4.1</span>
+   <li><a href="#offset-path-closest-side">closest-side</a><span>, in §4.1</span>
    <li><a href="#computed-distance">computed distance</a><span>, in §4.7.1</span>
    <li><a href="#offset-path-contain">contain</a><span>, in §4.1</span>
    <li><a href="#offset-path-farthest-corner">farthest-corner</a><span>, in §4.1</span>


### PR DESCRIPTION
Several of the ray() examples show unrotated boxes.

We now explicitly set the offset-rotation to 0deg, as the default
offset-rotation (auto) would cause rotation.