### PR TITLE
[motion] Clarify meaning of offset-anchor auto

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -382,7 +382,7 @@ unless the element is an SVG element without an associated CSS layout box.
 Name: offset-anchor
 Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Value: auto | <<position>>
-Initial: center
+Initial: auto
 Media: visual
 Inherited: no
 Percentages: Relative to the width and the height of an element
@@ -397,9 +397,11 @@ as the point that is moved along the <a>path</a>.
 Values have the following meanings:
 <dl dfn-for="offset-anchor" dfn-type="value">
 <dt><var>auto</var></dt>
-<dd>Computes to the value from 'offset-position'.
-	When ''auto'' is given to 'offset-anchor', 
-	'offset-position' behaves similar to 'background-position'.
+<dd>Computes to the value from 'offset-position', provided 'offset-path'
+	is ''none'' and 'offset-position' is not ''auto''. Otherwise, computes
+	to the value from 'transform-origin'. When ''auto'' is given to
+	'offset-anchor', and 'offset-path' is ''none'', 'offset-position'
+	behaves similar to 'background-position'.
 </dd>
 <dt><<position>></dt>
 <dd>

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-16">16 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-17">17 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -720,7 +720,7 @@ unless the element is an SVG element without an associated CSS layout box.</p>
       <td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
      <tr>
       <th>Initial:
-      <td>center
+      <td>auto
      <tr>
       <th>Applies to:
       <td><a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
@@ -749,8 +749,8 @@ as the point that is moved along the <a data-link-type="dfn" href="#path" id="re
    <p>Values have the following meanings:</p>
    <dl>
     <dt><var>auto</var>
-    <dd>Computes to the value from <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-2">offset-position</a>.
-	When <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-2">auto</a> is given to <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-2">offset-anchor</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-3">offset-position</a> behaves similar to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>. 
+    <dd>Computes to the value from <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-2">offset-position</a>, provided <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-7">offset-path</a> is <span class="css">none</span> and <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-3">offset-position</a> is not <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-2">auto</a>. Otherwise, computes
+	to the value from <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">transform-origin</a>. When <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-3">auto</a> is given to <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-2">offset-anchor</a>, and <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-8">offset-path</a> is <span class="css">none</span>, <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-4">offset-position</a> behaves similar to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>. 
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
     <dd>
      <dl>
@@ -858,7 +858,7 @@ as the point that is moved along the <a data-link-type="dfn" href="#path" id="re
 the angle of the direction 
 (i.e., directional tangent vector) of the <a data-link-type="dfn" href="#path" id="ref-for-path-13">path</a>. 
 If specified in combination with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added
-to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-3">auto</a>.
+to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-4">auto</a>.
     <dt><dfn class="dfn-paneled css" data-dfn-for="offset-rotation" data-dfn-type="value" data-export="" id="valdef-offset-rotation-reverse">reverse</dfn>
     <dd>
      Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-9">offset-distance</a> is animated) by
@@ -870,7 +870,7 @@ to the computed value of <a class="css" data-link-type="maybe" href="#valdef-off
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>
     <dd>Indicates that the element has a constant clockwise rotation transformation applied
 to it by the specified rotation angle.
-See definitions of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-4">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-2">reverse</a> if specified in combination with 
+See definitions of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-5">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-2">reverse</a> if specified in combination with 
 either one of the keywords.
    </dl>
    <p class="note" role="note">Note: The rotation described here does not override or replace any rotation defined by
@@ -888,7 +888,7 @@ The red dot in the middle of the shape indicates the origin of the shape.
      <figcaption>A black plane at different positions on a blue dotted path without 
 	rotation transforms.</figcaption>
     </div>
-    <p>If the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-3">offset-rotation</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-5">auto</a>, the shape’s point of origin is
+    <p>If the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-3">offset-rotation</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-6">auto</a>, the shape’s point of origin is
 placed at different positions along the path.
 The shape is rotated based on the gradient at the current position and faces 
 the direction of the path at this position.</p>
@@ -914,9 +914,9 @@ on the path.</p>
     </div>
    </div>
    <div class="example" id="example-b1ae1d7b">
-    <a class="self-link" href="#example-b1ae1d7b"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-6">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-4">reverse</a> works specified in combination 
+    <a class="self-link" href="#example-b1ae1d7b"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-7">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-4">reverse</a> works specified in combination 
 with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
-The computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-7">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-5">reverse</a>. 
+The computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-8">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-5">reverse</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span> <span class="p">{</span>
     border<span class="o">-</span><span class="n">radius</span><span class="o">:</span> <span class="m">50%</span><span class="p">;</span>
@@ -963,11 +963,11 @@ The computed value of <a class="production css" data-link-type="type" href="http
 </pre>
     <div class="figure">
       <img alt="An image of example for offset-rotation" src="images/rotate_by_angle_with_auto.png" style="width: 250px; text-align: center"> 
-     <figcaption>The elements are rotated by the value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-8">auto</a> with 
+     <figcaption>The elements are rotated by the value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-9">auto</a> with 
 	a fixed amount of degree.</figcaption>
     </div>
    </div>
-   <p class="issue" id="issue-5d73326d"><a class="self-link" href="#issue-5d73326d"></a> More natural names requested for <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-9">auto</a> and <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-6">reverse</a>.</p>
+   <p class="issue" id="issue-5d73326d"><a class="self-link" href="#issue-5d73326d"></a> More natural names requested for <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-10">auto</a> and <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-6">reverse</a>.</p>
    <p>See the section <a href="#offset-processing">“Offset processing”</a> for
 how to process an <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-6">offset-rotation</a>.</p>
    <h3 class="heading settled" data-level="4.6" id="offset-shorthand"><span class="secno">4.6. </span><span class="content">Offset shorthand: The <a class="property" data-link-type="propdesc" href="#propdef-offset" id="ref-for-propdef-offset-1">offset</a> property</span><a class="self-link" href="#offset-shorthand"></a></h3>
@@ -1004,7 +1004,7 @@ how to process an <a class="property" data-link-type="propdesc" href="#propdef-o
       <th>Animatable:
       <td>see individual properties
    </table>
-   <p>This is a shorthand property for setting <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-4">offset-position</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-7">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-10">offset-distance</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-7">offset-rotation</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-4">offset-anchor</a>.
+   <p>This is a shorthand property for setting <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-5">offset-position</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-9">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-10">offset-distance</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-7">offset-rotation</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-4">offset-anchor</a>.
 Omitted values are set to their initial values.</p>
    <h3 class="heading settled" data-level="4.7" id="offset-processing"><span class="secno">4.7. </span><span class="content">Offset processing</span><a class="self-link" href="#offset-processing"></a></h3>
    <h4 class="heading settled" data-level="4.7.1" id="calculating-the-computed-distance-along-a-path"><span class="secno">4.7.1. </span><span class="content">Calculating the computed distance along a path</span><a class="self-link" href="#calculating-the-computed-distance-along-a-path"></a></h4>
@@ -1260,6 +1260,7 @@ the element.</p>
     <ul>
      <li><a href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">local coordinate system</a>
      <li><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">transform</a>
+     <li><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">transform-origin</a>
     </ul>
    <li>
     <a data-link-type="biblio">[CSS3VAL]</a> defines the following terms:
@@ -1378,7 +1379,7 @@ the element.</p>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-anchor">offset-anchor</a>
       <td>auto | &lt;position>
-      <td>center
+      <td>auto
       <td>transformable elements
       <td>no
       <td>Relative to the width and the height of an element
@@ -1422,7 +1423,8 @@ the element.</p>
    <ul>
     <li><a href="#ref-for-propdef-offset-path-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-path-2">(2)</a> <a href="#ref-for-propdef-offset-path-3">(3)</a> <a href="#ref-for-propdef-offset-path-4">(4)</a>
     <li><a href="#ref-for-propdef-offset-path-5">4.2. Position on the path: The offset-distance property</a> <a href="#ref-for-propdef-offset-path-6">(2)</a>
-    <li><a href="#ref-for-propdef-offset-path-7">4.6. Offset shorthand: The offset property</a>
+    <li><a href="#ref-for-propdef-offset-path-7">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-propdef-offset-path-8">(2)</a>
+    <li><a href="#ref-for-propdef-offset-path-9">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="path">
@@ -1462,8 +1464,8 @@ the element.</p>
    <b><a href="#propdef-offset-position">#propdef-offset-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-position-1">4.3. Define the starting point of the path: The offset-position property</a>
-    <li><a href="#ref-for-propdef-offset-position-2">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-propdef-offset-position-3">(2)</a>
-    <li><a href="#ref-for-propdef-offset-position-4">4.6. Offset shorthand: The offset property</a>
+    <li><a href="#ref-for-propdef-offset-position-2">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-propdef-offset-position-3">(2)</a> <a href="#ref-for-propdef-offset-position-4">(3)</a>
+    <li><a href="#ref-for-propdef-offset-position-5">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-offset-anchor">
@@ -1485,8 +1487,8 @@ the element.</p>
    <b><a href="#valdef-offset-rotation-auto">#valdef-offset-rotation-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-offset-rotation-auto-1">4.3. Define the starting point of the path: The offset-position property</a>
-    <li><a href="#ref-for-valdef-offset-rotation-auto-2">4.4. Define an anchor point: The offset-anchor property</a>
-    <li><a href="#ref-for-valdef-offset-rotation-auto-3">4.5. Rotation at point: The offset-rotation property</a> <a href="#ref-for-valdef-offset-rotation-auto-4">(2)</a> <a href="#ref-for-valdef-offset-rotation-auto-5">(3)</a> <a href="#ref-for-valdef-offset-rotation-auto-6">(4)</a> <a href="#ref-for-valdef-offset-rotation-auto-7">(5)</a> <a href="#ref-for-valdef-offset-rotation-auto-8">(6)</a> <a href="#ref-for-valdef-offset-rotation-auto-9">(7)</a>
+    <li><a href="#ref-for-valdef-offset-rotation-auto-2">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-valdef-offset-rotation-auto-3">(2)</a>
+    <li><a href="#ref-for-valdef-offset-rotation-auto-4">4.5. Rotation at point: The offset-rotation property</a> <a href="#ref-for-valdef-offset-rotation-auto-5">(2)</a> <a href="#ref-for-valdef-offset-rotation-auto-6">(3)</a> <a href="#ref-for-valdef-offset-rotation-auto-7">(4)</a> <a href="#ref-for-valdef-offset-rotation-auto-8">(5)</a> <a href="#ref-for-valdef-offset-rotation-auto-9">(6)</a> <a href="#ref-for-valdef-offset-rotation-auto-10">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valdef-offset-rotation-reverse">


### PR DESCRIPTION
offset-position is only used when offset-path is none and
offset-position is not auto. Otherwise, transform-origin is used.

Resolves #46