### PR TITLE
[motion] Initial position and direction for geometry-box

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -219,7 +219,7 @@ Values have the following meanings:
 	</dl>
 </dd>
 
-<dt><<basic-shape>></dt>
+<dt><<basic-shape>> || <<geometry-box>></dt>
 <dd>The path is a basic shape as specified in CSS Shapes [[!CSS-SHAPES]].
 The initial position and the initial direction for basic shapes are defined as follows:
 	<dl>
@@ -241,6 +241,28 @@ The initial position and the initial direction for basic shapes are defined as f
 		If there is no such unequal coordinate pair, the initial direction is 
 		defined with 0 degree.</dd>
 	</dl>
+
+	If <<geometry-box>> is supplied without a <<basic-shape>>, the initial position is the left end of the top horizontal line, immediately to the right of any 'border-radius' arc, and the initial direction is to the right.
+
+	<div class='example'>
+		This example shows how &lt;geometry-box> paths work in combination with 'border-radius'.
+
+		<pre class="lang-html">
+			&lt;style>
+				body {
+					border-radius: 80px;
+					margin: 0;
+				}
+			&lt;/style>
+			&lt;body>
+				&lt;div style="offset-path: margin-box">&lt;/div>
+			&lt;/body>
+		</pre>
+		<div class="figure">
+			<img alt="An image of example for geometry-box with border-radius" src="images/geometry-box.svg" style="width: 470px; text-align: center"/>
+			<figcaption>The initial position is the left end of the top horizontal line.</figcaption>
+		</div>
+	</div>
 	</dd>
 	<dt><dfn>path()</dfn> = path(<<string>>)</dt>
 	<dd>The <<string>> represents an SVG Path data string.

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-01">1 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-09">9 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -533,7 +533,7 @@ and its ancestors have no transformation applied.</p>
        </div>
       </div>
      </dl>
-    <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a>
+    <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> || <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a>
     <dd>
      The path is a basic shape as specified in CSS Shapes <a data-link-type="biblio" href="#biblio-css-shapes">[CSS-SHAPES]</a>.
 The initial position and the initial direction for basic shapes are defined as follows: 
@@ -556,6 +556,24 @@ The initial position and the initial direction for basic shapes are defined as f
 		If there is no such unequal coordinate pair, the initial direction is 
 		defined with 0 degree.
      </dl>
+     <p>If <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> is supplied without a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a>, the initial position is the left end of the top horizontal line, immediately to the right of any <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a> arc, and the initial direction is to the right.</p>
+     <div class="example" id="example-4a51b65e">
+      <a class="self-link" href="#example-4a51b65e"></a> This example shows how &lt;geometry-box> paths work in combination with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a>. 
+<pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="nt">body</span> <span class="p">{</span>
+    border<span class="o">-</span><span class="n">radius</span><span class="o">:</span> <span class="m">80px</span><span class="p">;</span>
+    margin<span class="o">:</span> <span class="m">0</span><span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">style</span><span class="o">=</span><span class="s">"offset-path: margin-box"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">body</span><span class="p">></span>
+</pre>
+      <div class="figure">
+        <img alt="An image of example for geometry-box with border-radius" src="images/geometry-box.svg" style="width: 470px; text-align: center"> 
+       <figcaption>The initial position is the left end of the top horizontal line.</figcaption>
+      </div>
+     </div>
     <dt><dfn class="css" data-dfn-for="offset-path" data-dfn-type="function" data-export="" id="funcdef-offset-path-path">path()<a class="self-link" href="#funcdef-offset-path-path"></a></dfn> = path(<a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#string-value">&lt;string></a>)
     <dd>The <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#string-value">&lt;string></a> represents an SVG Path data string.
 		The path data string must be conform to the grammar and parsing rules of SVG 1.1 <a data-link-type="biblio" href="#biblio-svg11">[SVG11]</a>.
@@ -1193,6 +1211,7 @@ the element.</p>
     <ul>
      <li><a href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
      <li><a href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>
+     <li><a href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-cascade-4]</a> defines the following terms:

--- a/motion-1/images/geometry-box.svg
+++ b/motion-1/images/geometry-box.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="470" height="270">
+<style>
+  .boundary {fill: none;stroke: #ccc;stroke-width: 2;stroke-dasharray: 5,3;}
+  .path {fill:none;stroke: cyan;stroke-width: 3;stroke-dasharray: 15,10;}
+  .placed {fill:blue; stroke:none;}
+</style>
+<rect class="boundary" x="10" y="22" width="440" height="240" />
+<rect class="path" x="10" y="22" width="440" height="240" rx="80" ry="80" />
+<rect class="placed" x="68" y="0" width="44" height="44" />
+</svg>


### PR DESCRIPTION
The initial position and direction for geometry-box are the
same as for SVG rect: (x+rx,y) and to the right:
https://svgwg.org/svg2-draft/shapes.html#RectElement

Resolves #82