### PR TITLE
[motion] offset-rotation is not a bearing.

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -492,13 +492,10 @@ to the computed value of ''auto''.</dd>
 </dd>
 
 <dt><<angle>></dt>
-<dd>Indicates that the element has a constant rotation transformation applied to it 
-by the specified rotation angle.
+<dd>Indicates that the element has a constant clockwise rotation transformation applied
+to it by the specified rotation angle.
 See definitions of ''auto'' or ''reverse'' if specified in combination with 
-either one of the keywords.
-For the purpose of this argument, ''0deg'' points to the right side in the direction of 
-the positive y-axis, and positive angles represent clockwise rotation, 
-so ''90deg'' point toward the direction of the positive x-axis.</dd>
+either one of the keywords.</dd>
 </dl>
 
 Note: The rotation described here does not override or replace any rotation defined by 
@@ -513,7 +510,7 @@ The red dot in the middle of the shape indicates the origin of the shape.
 </div>
 
 When the shape's point of origin is placed at different positions along the path and 
-'offset-rotation' isn't specified, the shape points to the positive direction of the x-axis.
+'offset-rotation' is '0deg', the shape is not rotated.
 <div class=figure>
 	<img src="images/offset-rotation-none.svg" width="470" height="120" alt="Path without rotation">
 	<figcaption>A black plane at different positions on a blue dotted path without 
@@ -539,8 +536,8 @@ The plane faces the opposite direction of the path at each position on the path.
 	rotated in the opposite direction of the path.</figcaption>
 </div>
 
-The last example sets the 'offset-rotation' property to ''45deg''.
-The shape is rotated by 45 degree once and keeps the rotation at each position 
+The last example sets the 'offset-rotation' property to ''-45deg''.
+The shape is rotated anticlockwise by 45 degree once and keeps the rotation at each position
 on the path.
 <div class=figure>
 	<img src="images/offset-rotation-45.svg" width="470" height="120" alt="Path with fixed rotation">

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-09">9 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-14">14 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -853,24 +853,21 @@ to the computed value of <a class="css" data-link-type="maybe" href="#valdef-off
 	to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-1">reverse</a>. 
      <p class="note" role="note">This is the same as specifying <span class="css">auto 180deg</span>. </p>
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>
-    <dd>Indicates that the element has a constant rotation transformation applied to it 
-by the specified rotation angle.
+    <dd>Indicates that the element has a constant clockwise rotation transformation applied
+to it by the specified rotation angle.
 See definitions of <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-auto" id="ref-for-valdef-offset-rotation-auto-4">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotation-reverse" id="ref-for-valdef-offset-rotation-reverse-2">reverse</a> if specified in combination with 
 either one of the keywords.
-For the purpose of this argument, <span class="css">0deg</span> points to the right side in the direction of 
-the positive y-axis, and positive angles represent clockwise rotation, 
-so <span class="css">90deg</span> point toward the direction of the positive x-axis.
    </dl>
    <p class="note" role="note">Note: The rotation described here does not override or replace any rotation defined by
 the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">transform</a> property.</p>
-   <div class="example" id="example-4d1dd03c">
-    <a class="self-link" href="#example-4d1dd03c"></a> The following examples use the shape of a plane. 
+   <div class="example" id="example-1bc25b14">
+    <a class="self-link" href="#example-1bc25b14"></a> The following examples use the shape of a plane. 
 The red dot in the middle of the shape indicates the origin of the shape. 
     <div class="figure">
       <img alt="Shape with its origin" height="140" src="images/plane.svg" width="160"> 
      <figcaption>A red dot in the middle of a plane shape indicates the shape’s origin.</figcaption>
     </div>
-    <p>When the shape’s point of origin is placed at different positions along the path and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-2">offset-rotation</a> isn’t specified, the shape points to the positive direction of the x-axis.</p>
+    <p>When the shape’s point of origin is placed at different positions along the path and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-2">offset-rotation</a> is <a class="property" data-link-type="propdesc">0deg</a>, the shape is not rotated.</p>
     <div class="figure">
       <img alt="Path without rotation" height="120" src="images/offset-rotation-none.svg" width="470"> 
      <figcaption>A black plane at different positions on a blue dotted path without 
@@ -892,8 +889,8 @@ The plane faces the opposite direction of the path at each position on the path.
      <figcaption>A black plane at different positions on a blue dotted path, 
 	rotated in the opposite direction of the path.</figcaption>
     </div>
-    <p>The last example sets the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-5">offset-rotation</a> property to <span class="css">45deg</span>.
-The shape is rotated by 45 degree once and keeps the rotation at each position 
+    <p>The last example sets the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotation" id="ref-for-propdef-offset-rotation-5">offset-rotation</a> property to <span class="css">-45deg</span>.
+The shape is rotated anticlockwise by 45 degree once and keeps the rotation at each position
 on the path.</p>
     <div class="figure">
       <img alt="Path with fixed rotation" height="120" src="images/offset-rotation-45.svg" width="470"> 


### PR DESCRIPTION
The text was previously confused, for example saying "0deg points to the
right side in the direction of the positive y-axis".

As the initial value is 'auto', "offset-rotation isn’t specified" would
be equivalent to auto. The example in Figure 8 now uses '0deg' to avoid
rotation transformations.