### PR TITLE
[motion] <angle> notation should be defined as bearing angles

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -125,11 +125,10 @@ Values have the following meanings:
 <dl dfn-for="offset-path">
 <dt><<angle>></dt>
 <dd>
-	The path is a line segment that starts from the position of the element 
-	and proceeds in the direction defined by  the specified <<angle>> from the y axis.
-	For <<angle>>, the initial value ''none'' is interpreted as ''0deg'',
-	the element can be positioned along the y axis.
-	If the <<angle>> value increases in the positive direction, the element moves clockwise.
+	The path is a line segment that starts from the position of the element and proceeds in the
+	direction defined by the specified <<angle>>. As with
+	<a href="https://www.w3.org/TR/css3-images/#gradients">CSS gradients</a>, <<angle>> values are interpreted
+	as bearing angles, with '0deg' pointing up and positive angles representing clockwise rotation.
 	
 	<p class="note">Note: Defining a path with <<angle>>, 
 	the element can be positioned with the used of polar coordinates.

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-09">9 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-14">14 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -460,11 +460,9 @@ and its ancestors have no transformation applied.</p>
    <dl>
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>
     <dd>
-      The path is a line segment that starts from the position of the element 
-	and proceeds in the direction defined by  the specified <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> from the y axis.
-	For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the initial value <span class="css">none</span> is interpreted as <span class="css">0deg</span>,
-	the element can be positioned along the y axis.
-	If the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> value increases in the positive direction, the element moves clockwise. 
+      The path is a line segment that starts from the position of the element and proceeds in the
+	direction defined by the specified <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. As with <a href="https://www.w3.org/TR/css3-images/#gradients">CSS gradients</a>, <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> values are interpreted
+	as bearing angles, with <a class="property" data-link-type="propdesc">0deg</a> pointing up and positive angles representing clockwise rotation. 
      <p class="note" role="note">Note: Defining a path with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, 
 	the element can be positioned with the used of polar coordinates.
 	The polar coordinate system is a two-dimensional coordinate system in which each point on a plane


### PR DESCRIPTION
The description is now clearer, using text suggested by fantasai.

Resolves #63