### PR TITLE
[motion] properties apply only to transformable elements

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -99,7 +99,7 @@ ISSUE: Add more details and examples.
 Name: offset-path
 Value: <<url>> | ray(<<angle>> && <<size>>? && contain?) | <<basic-shape>> || <<geometry-box>> | <<path()>> | none
 Initial: none
-Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <{defs}> element and all <a>graphics elements</a>
+Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Inherited: no
 Percentages: n/a
 Computed value: as specified
@@ -296,7 +296,7 @@ For elements with associated CSS layout box, the <a>used value</a> for <a value 
 Name: offset-distance
 Value: <<length-percentage>>
 Initial: 0
-Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <{defs}> element and all <a>graphics elements</a>
+Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Inherited: no
 Percentages: refer to the total path length
 Computed value: For <<length>> the absolute value, otherwise a percentage.
@@ -348,7 +348,7 @@ This example shows a way to align elements within the polar coordinate system us
 <h3 id="offset-position-property">Define the starting point of the path: The 'offset-position' property</h3>
 <pre class='propdef'>
 Name: offset-position
-Applies to: all elements
+Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Value: auto | <<position>>
 Initial: auto
 Media: visual
@@ -380,7 +380,7 @@ unless the element is an SVG element without an associated CSS layout box.
 <h3 id="offset-anchor-property">Define an anchor point: The 'offset-anchor' property</h3>
 <pre class='propdef'>
 Name: offset-anchor
-Applies to: All elements
+Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Value: auto | <<position>>
 Initial: center
 Media: visual
@@ -481,7 +481,7 @@ This example shows an alignment of four elements with different anchor points.
 Name: offset-rotation
 Value: [ auto | reverse ] || <<angle>>
 Initial: auto
-Applies to: All elements. In SVG, it applies to <a href="">container elements</a> excluding the <{defs}> element and all <a>graphics elements</a>
+Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Inherited: no
 Percentages: n/a
 Computed value: as specified
@@ -633,7 +633,7 @@ how to process an 'offset-rotation'.
 	Name: offset
 	Value: &lt;'offset-path'> && &lt;'offset-distance'> && &lt;'offset-position'> && &lt;'offset-anchor'> && &lt;'offset-rotation'>
 	Initial: see individual properties
-	Applies to: All elements. In SVG, it applies to <a href="">container elements</a> excluding the <{defs}> element and all <a>graphics elements</a>
+	Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 	Inherited: no
 	Percentages: see individual properties
 	Computed value: see individual properties

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -425,7 +425,7 @@
       <td>none
      <tr>
       <th>Applies to:
-      <td>All elements. In SVG, it applies to <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/struct.html#container-element">container elements</a> excluding the <code><a data-link-type="element" href="https://www.w3.org/TR/SVG11/struct.html#DefsElement">defs</a></code> element and all <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/struct.html#graphics-element">graphics elements</a>
+      <td><a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
      <tr>
       <th>Inherited:
       <td>no
@@ -604,7 +604,7 @@ or is non-existent is ignored. No path and no stacking context are created.</p>
       <td>0
      <tr>
       <th>Applies to:
-      <td>All elements. In SVG, it applies to <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/struct.html#container-element">container elements</a> excluding the <code><a data-link-type="element" href="https://www.w3.org/TR/SVG11/struct.html#DefsElement">defs</a></code> element and all <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/struct.html#graphics-element">graphics elements</a>
+      <td><a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
      <tr>
       <th>Inherited:
       <td>no
@@ -675,7 +675,7 @@ the initial position and the end position of the <a data-link-type="dfn" href="#
       <td>auto
      <tr>
       <th>Applies to:
-      <td><a href="https://drafts.csswg.org/css-pseudo/#generated-content" title="Includes ::before and ::after pseudo-elements.">all elements</a>
+      <td><a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
      <tr>
       <th>Inherited:
       <td>no
@@ -723,7 +723,7 @@ unless the element is an SVG element without an associated CSS layout box.</p>
       <td>center
      <tr>
       <th>Applies to:
-      <td><a href="https://drafts.csswg.org/css-pseudo/#generated-content" title="Includes ::before and ::after pseudo-elements.">all elements</a>
+      <td><a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
      <tr>
       <th>Inherited:
       <td>no
@@ -830,7 +830,7 @@ as the point that is moved along the <a data-link-type="dfn" href="#path" id="re
       <td>auto
      <tr>
       <th>Applies to:
-      <td>All elements. In SVG, it applies to <a href="">container elements</a> excluding the <code><a data-link-type="element" href="https://www.w3.org/TR/SVG11/struct.html#DefsElement">defs</a></code> element and all <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/struct.html#graphics-element">graphics elements</a>
+      <td><a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
      <tr>
       <th>Inherited:
       <td>no
@@ -984,7 +984,7 @@ how to process an <a class="property" data-link-type="propdesc" href="#propdef-o
       <td>see individual properties
      <tr>
       <th>Applies to:
-      <td>All elements. In SVG, it applies to <a href="">container elements</a> excluding the <code><a data-link-type="element" href="https://www.w3.org/TR/SVG11/struct.html#DefsElement">defs</a></code> element and all <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/struct.html#graphics-element">graphics elements</a>
+      <td><a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
      <tr>
       <th>Inherited:
       <td>no
@@ -1285,15 +1285,8 @@ the element.</p>
      <li><a href="https://drafts.csswg.org/css21/visuren.html#x43">stacking context</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[SVG11]</a> defines the following terms:
-    <ul>
-     <li><a href="https://www.w3.org/TR/SVG11/struct.html#DefsElement">defs</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[SVG2]</a> defines the following terms:
     <ul>
-     <li><a href="https://svgwg.org/svg2-draft/struct.html#container-element">container element</a>
-     <li><a href="https://svgwg.org/svg2-draft/struct.html#graphics-element">graphics element</a>
      <li><a href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a>
     </ul>
   </ul>
@@ -1352,7 +1345,7 @@ the element.</p>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-path">offset-path</a>
       <td>&lt;url> | ray(&lt;angle> &amp;&amp; &lt;size>? &amp;&amp; contain?) | &lt;basic-shape> || &lt;geometry-box> | &lt;path()> | none
       <td>none
-      <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
+      <td>transformable elements
       <td>no
       <td>n/a
       <td>visual
@@ -1363,7 +1356,7 @@ the element.</p>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-distance">offset-distance</a>
       <td>&lt;length-percentage>
       <td>0
-      <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
+      <td>transformable elements
       <td>no
       <td>refer to the total path length
       <td>visual
@@ -1374,7 +1367,7 @@ the element.</p>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-position">offset-position</a>
       <td>auto | &lt;position>
       <td>auto
-      <td>all elements
+      <td>transformable elements
       <td>no
       <td>Refer to the size of containing block
       <td>visual
@@ -1385,7 +1378,7 @@ the element.</p>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-anchor">offset-anchor</a>
       <td>auto | &lt;position>
       <td>center
-      <td>all elements
+      <td>transformable elements
       <td>no
       <td>Relative to the width and the height of an element
       <td>visual
@@ -1396,7 +1389,7 @@ the element.</p>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-rotation">offset-rotation</a>
       <td>[ auto | reverse ] || &lt;angle>
       <td>auto
-      <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
+      <td>transformable elements
       <td>no
       <td>n/a
       <td>visual
@@ -1407,7 +1400,7 @@ the element.</p>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset">offset</a>
       <td>&lt;offset-path> &amp;&amp; &lt;offset-distance> &amp;&amp; &lt;offset-position> &amp;&amp; &lt;offset-anchor> &amp;&amp; &lt;offset-rotation>
       <td>see individual properties
-      <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
+      <td>transformable elements
       <td>no
       <td>see individual properties
       <td>visual


### PR DESCRIPTION
As suggested by dbaron, the CSS Motion Path properties apply only
to transformable properties.

Resolves #58