### PR TITLE
SVGClipPathElement and SVGMaskElement no longer implement SVGUnitTypes.

### DIFF
--- a/css-masking-1/Overview.html
+++ b/css-masking-1/Overview.html
@@ -263,7 +263,7 @@ a[data-link-type=element]::after,span[data-link-type=element]::after {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>CSS Masking Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-24">24 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-30">30 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1871,8 +1871,7 @@ p#two { clip: rect(5px, 55px, 45px, 5px); }</code></pre>
 <pre class="idl def" data-no-idl="">interface <b>SVGClipPathElement</b> : <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGElement">SVGElement</a> {  readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGAnimatedEnumeration">SVGAnimatedEnumeration</a> <a data-link-type="element-attr" href="#element-attrdef-clippath-clippathunits" id="ref-for-element-attrdef-clippath-clippathunits-3">clipPathUnits</a>;
   readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/coords.html#InterfaceSVGAnimatedTransformList">SVGAnimatedTransformList</a> <a href="#SVGClipPathElement__transform">transform</a>;
 };
-
-<a href="#InterfaceSVGClipPathElement">SVGClipPathElement</a> implements <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGUnitTypes">SVGUnitTypes</a>;</pre>
+</pre>
    <dl class="interface">
     <dt class="attributes-header">Attributes:
     <dd>
@@ -1894,8 +1893,7 @@ p#two { clip: rect(5px, 55px, 45px, 5px); }</code></pre>
   readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGAnimatedLength">SVGAnimatedLength</a> <a href="#SVGMaskElement__width">width</a>;
   readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGAnimatedLength">SVGAnimatedLength</a> <a href="#SVGMaskElement__height">height</a>;
 };
-
-<a href="#InterfaceSVGMaskElement">SVGMaskElement</a> implements <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGUnitTypes">SVGUnitTypes</a>;</pre>
+</pre>
    <dl class="interface">
     <dt class="attributes-header">Attributes:
     <dd>
@@ -2722,7 +2720,6 @@ p#two { clip: rect(5px, 55px, 45px, 5px); }</code></pre>
   readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/coords.html#InterfaceSVGAnimatedTransformList">SVGAnimatedTransformList</a> <a href="#SVGClipPathElement__transform">transform</a>;
 };
 
-<a href="#InterfaceSVGClipPathElement">SVGClipPathElement</a> implements <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGUnitTypes">SVGUnitTypes</a>;
 interface <b>SVGMaskElement</b> : <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGElement">SVGElement</a> {  readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGAnimatedEnumeration">SVGAnimatedEnumeration</a> <a href="#SVGMaskElement__maskUnits">maskUnits</a>;
   readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGAnimatedEnumeration">SVGAnimatedEnumeration</a> <a href="#SVGMaskElement__maskContentUnits">maskContentUnits</a>;
   readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGAnimatedLength">SVGAnimatedLength</a> <a href="#SVGMaskElement__x">x</a>;
@@ -2731,7 +2728,6 @@ interface <b>SVGMaskElement</b> : <a href="https://www.w3.org/TR/2011/REC-SVG11-
   readonly attribute <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGAnimatedLength">SVGAnimatedLength</a> <a href="#SVGMaskElement__height">height</a>;
 };
 
-<a href="#InterfaceSVGMaskElement">SVGMaskElement</a> implements <a href="https://www.w3.org/TR/2011/REC-SVG11-20110816/types.html#InterfaceSVGUnitTypes">SVGUnitTypes</a>;
 </pre>
   <aside class="dfn-panel" data-for="clipping-path">
    <b><a href="#clipping-path">#clipping-path</a></b><b>Referenced in:</b>

--- a/css-masking-1/Overview.src.html
+++ b/css-masking-1/Overview.src.html
@@ -1357,8 +1357,7 @@ Note: A future version of the SVG specification may override this section.
   readonly attribute <a>SVGAnimatedEnumeration</a> <a element-attr>clipPathUnits</a>;
   readonly attribute <a>SVGAnimatedTransformList</a> <a href="#SVGClipPathElement__transform">transform</a>;
 };
-
-<a>SVGClipPathElement</a> implements <a>SVGUnitTypes</a>;</pre>
+</pre>
 
 <dl class="interface">
 <dt class="attributes-header">Attributes:</dt>
@@ -1396,8 +1395,7 @@ Corresponds to presentation attribute 'transform' on the given element.
   readonly attribute <a>SVGAnimatedLength</a> <a href="#SVGMaskElement__width">width</a>;
   readonly attribute <a>SVGAnimatedLength</a> <a href="#SVGMaskElement__height">height</a>;
 };
-
-<a>SVGMaskElement</a> implements <a>SVGUnitTypes</a>;</pre>
+</pre>
 
 <dl class="interface">
 <dt class="attributes-header">Attributes:</dt>


### PR DESCRIPTION
Closes #90.
Related to w3c/svgwg/#291 and w3c/svgwg/#295.