### PR TITLE
[motion] Failed references treated as zero-length paths

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -275,7 +275,7 @@ The initial position and the initial direction for basic shapes are defined as f
 				}
 				#blueBox{
 					width: 40px;
-					height: 40px;
+					height: 20px;
 					background-color: blue;
 					offset-path: margin-box;
 				}
@@ -308,7 +308,9 @@ the same way that CSS 'opacity' [[CSS3COLOR]] does for values other than ''1'',
 unless the element is an SVG element without an associated CSS layout box.
 
 A reference that fails to download, is not a reference to an SVG <a>shape element</a> element,
-or is non-existent is ignored. No <a>offset path</a> and no stacking context are created.
+or is non-existent, is treated as equivalent to ''path("m 0 0")''.
+
+<p class='note'>Note: This is a zero length path with <a href="https://www.w3.org/TR/SVG11/implnote.html#PathElementImplementationNotes">directionality</a> aligned with the positive x-axis.</p>
 
 See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a>offset path</a>.
 
@@ -744,14 +746,16 @@ Values have the following meanings:
 <dt><dfn>auto</dfn></dt>
 <dd>Indicates that the object is rotated (over time if 'offset-distance' is animated) by 
 the angle of the direction 
-(i.e., directional tangent vector) of the <a>path</a>. 
+(i.e., directional tangent vector) of the <a>path</a>, relative to the positive x-axis.
 If specified in combination with <<angle>>, the computed value of <<angle>> is added
 to the computed value of ''auto''.</dd>
+
+<p class='note'>Note: For ray paths, the rotation implied by 'auto' is 90 degrees less than the ray's bearing <<angle>>.</p>
 
 <dt><dfn>reverse</dfn></dt>
 <dd>Indicates that the object is rotated (over time if 'offset-distance' is animated) by
  the angle of the direction 
-(i.e., directional tangent vector) of the <a>path</a> plus 180 degrees. 
+(i.e., directional tangent vector) of the <a>path</a>, relative to the positive x-axis, plus 180 degrees.
 	If specified in combination with <<angle>>, the computed value of <<angle>> is added 
 	to the computed value of ''reverse''.
 
@@ -814,7 +818,7 @@ on the path.
 </div>
 
 <div class='example'>
-This example shows how ''auto'' or ''reverse'' works specified in combination 
+This example shows how ''auto'' or ''reverse'' work when specified in combination
 with <<angle>>. 
 The computed value of <<angle>> is added to the computed value of ''auto'' or ''reverse''.
 
@@ -855,12 +859,12 @@ The computed value of <<angle>> is added to the computed value of ''auto'' or ''
 		#item5 {
 			offset-path: ray(225deg);
 			offset-distance: 90%;
-			offset-rotate: auto -90deg;
+			offset-rotate: reverse 90deg;
 		}
 		#item6 {
 			offset-path: ray(-45deg);
 			offset-distance: 90%;
-			offset-rotate: auto 90deg;
+			offset-rotate: reverse -90deg;
 		}
 	&lt;/style>
 	&lt;body>

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -7,7 +7,7 @@
   <link href="../default.css" rel="stylesheet" type="text/css">
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version 176d39d5a285c04f57d2f0e078fa69273028eb45" name="generator">
+  <meta content="Bikeshed version 237216488a585c6f0fbfeb6dc67a26c10fd1d88d" name="generator">
 <style>
   /* Style for bikeshed variant of switch/case <dl>s */
   div.switch dl > dd > ol.only {
@@ -290,7 +290,7 @@ editors
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-23">23 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-21">21 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -309,7 +309,7 @@ editors
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -517,39 +517,39 @@ and its ancestors have no transformation applied.</p>
   <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
   <span class="k">height</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
   <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">45</span><span class="l">deg</span><span class="p">)</span><span class="p">;</span>
-  <span class="k">offset-distance</span><span class="p">:</span> <span class="m">10</span><span class="l">0</span>%;
-}
-#blueBox {
-  background-color: blue;
-  width: 50px;
-  height: 50px;
-  offset-path: ray(180deg);
-  offset-distance: 100%;
-}
+  <span class="k">offset-distance</span><span class="p">:</span> <span class="m">100</span><span class="l">%</span><span class="p">;</span>
+<span class="p">}</span>
+<span class="nt">#blueBox </span><span class="p">{</span>
+  <span class="k">background-color</span><span class="p">:</span> blue<span class="p">;</span>
+  <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
+  <span class="k">height</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
+  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">180</span><span class="l">deg</span><span class="p">)</span><span class="p">;</span>
+  <span class="k">offset-distance</span><span class="p">:</span> <span class="m">100</span><span class="l">%</span><span class="p">;</span>
+<span class="p">}</span>
 </pre>
        <div class="figure">
          <img alt="An image of elements positioned without contain" src="images/offset_distance_without_contain.png" style="width: 200px;"> 
-        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-2">offset-path</a> without <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a></figcaption>
+        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-2">offset-path</a> without <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a></figcaption>
        </div>
-       <p>In the second example, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a> is given to the <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-3">offset-path</a> value of each element
+       <p>In the second example, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a> is given to the <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-3">offset-path</a> value of each element
 		to avoid overflowing.</p>
 <pre class="lang-css highlight"><span class="nt">#redBox </span><span class="p">{</span>
   <span class="k">background-color</span><span class="p">:</span> red<span class="p">;</span>
   <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
   <span class="k">height</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
   <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">45</span><span class="l">deg</span> contain<span class="p">)</span><span class="p">;</span>
-  <span class="k">offset-distance</span><span class="p">:</span> <span class="m">10</span><span class="l">0</span>%;
-}
-#blueBox {
-  background-color: blue;
-  width: 50px;
-  height: 50px;
-  offset-path: ray(180deg contain);
-}
+  <span class="k">offset-distance</span><span class="p">:</span> <span class="m">100</span><span class="l">%</span><span class="p">;</span>
+<span class="p">}</span>
+<span class="nt">#blueBox </span><span class="p">{</span>
+  <span class="k">background-color</span><span class="p">:</span> blue<span class="p">;</span>
+  <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
+  <span class="k">height</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
+  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">180</span><span class="l">deg</span> contain<span class="p">)</span><span class="p">;</span>
+<span class="p">}</span>
 </pre>
        <div class="figure">
          <img alt="An image of elements positioned with contain" src="images/offset_distance_with_contain.png" style="width: 200px;"> 
-        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-4">offset-path</a> with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a></figcaption>
+        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-4">offset-path</a> with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a></figcaption>
        </div>
       </div>
      </dl>
@@ -577,8 +577,8 @@ The initial position and the initial direction for basic shapes are defined as f
 		defined as 0 degrees.
      </dl>
      <p>If <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> is supplied without a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a>, the initial position is the left end of the top horizontal line, immediately to the right of any <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a> arc, and the initial direction is to the right.</p>
-     <div class="example" id="example-e68e9d31">
-      <a class="self-link" href="#example-e68e9d31"></a> This example shows how &lt;geometry-box> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-12">offset path</a> works in combination with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a>. 
+     <div class="example" id="example-c7cc0c3f">
+      <a class="self-link" href="#example-c7cc0c3f"></a> This example shows how &lt;geometry-box> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-12">offset path</a> works in combination with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span><span class="p">{</span>
     width<span class="o">:</span> <span class="m">500px</span><span class="p">;</span>
@@ -589,7 +589,7 @@ The initial position and the initial direction for basic shapes are defined as f
   <span class="p">}</span>
   <span class="nn">#blueBox</span><span class="p">{</span>
     width<span class="o">:</span> <span class="m">40px</span><span class="p">;</span>
-    height<span class="o">:</span> <span class="m">40px</span><span class="p">;</span>
+    height<span class="o">:</span> <span class="m">20px</span><span class="p">;</span>
     background-color<span class="o">:</span> blue<span class="p">;</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> margin<span class="o">-</span><span class="n">box</span><span class="p">;</span>
   <span class="p">}</span>
@@ -616,8 +616,9 @@ The initial position and the initial direction for basic shapes are defined as f
    <p>A computed value of other than <span class="css">none</span> results in the creation of a <a data-link-type="dfn" href="https://drafts.csswg.org/css21/visuren.html#x43">stacking context</a> <a data-link-type="biblio" href="#biblio-css21">[CSS21]</a> the same way that CSS <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a> <a data-link-type="biblio" href="#biblio-css3color">[CSS3COLOR]</a> does for values other than <span class="css">1</span>,
 unless the element is an SVG element without an associated CSS layout box.</p>
    <p>A reference that fails to download, is not a reference to an SVG <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a> element,
-or is non-existent is ignored. No <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-15">offset path</a> and no stacking context are created.</p>
-   <p>See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-16">offset path</a>.</p>
+or is non-existent, is treated as equivalent to <span class="css">path("m 0 0")</span>.</p>
+   <p class="note" role="note">Note: This is a zero length path with <a href="https://www.w3.org/TR/SVG11/implnote.html#PathElementImplementationNotes">directionality</a> aligned with the positive x-axis.</p>
+   <p>See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-15">offset path</a>.</p>
    <p>For SVG elements without associated CSS layout box, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#used-value">used value</a> for <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-content-box">content-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-padding-box">padding-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box">border-box</a> and <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-margin-box">margin-box</a> is <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box">fill-box</a>.</p>
    <p>For elements with associated CSS layout box, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#used-value">used value</a> for <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box">fill-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-stroke-box">stroke-box</a> and <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-view-box">view-box</a> is <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box">border-box</a>.</p>
    <h3 class="heading settled" data-level="4.2" id="offset-distance-property"><span class="secno">4.2. </span><span class="content">Position on the path: The <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-4">offset-distance</a> property</span><a class="self-link" href="#offset-distance-property"></a></h3>
@@ -646,7 +647,7 @@ or is non-existent is ignored. No <a data-link-type="dfn" href="#offset-path" id
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -654,37 +655,37 @@ or is non-existent is ignored. No <a data-link-type="dfn" href="#offset-path" id
       <th>Animatable:
       <td>yes
    </table>
-   <p>Specifies the position of the element as a distance along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-17">offset path</a>.</p>
+   <p>Specifies the position of the element as a distance along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-16">offset path</a>.</p>
    <dl>
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">&lt;length-percentage></a>
     <dd>
-     Specifies the distance from the initial position of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-18">offset path</a> to the position of the box’s anchor point. 
-     <p>Percentages are relative to the length of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-19">offset path</a>—<wbr>that is, the distance between 
-the initial position and the end position of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-20">offset path</a>.</p>
+     Specifies the distance from the initial position of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-17">offset path</a> to the position of the box’s anchor point. 
+     <p>Percentages are relative to the length of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-18">offset path</a>—<wbr>that is, the distance between 
+the initial position and the end position of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-19">offset path</a>.</p>
     <p></p>
    </dl>
    <h4 class="heading settled" data-level="4.2.1" id="calculating-the-computed-distance-along-a-path"><span class="secno">4.2.1. </span><span class="content">Calculating the computed distance along a path</span><a class="self-link" href="#calculating-the-computed-distance-along-a-path"></a></h4>
-   <p>Processing the distance along an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-21">offset path</a> operates differently depending upon the nature of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-22">offset path</a>:</p>
+   <p>Processing the distance along an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-20">offset path</a> operates differently depending upon the nature of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-21">offset path</a>:</p>
    <ul>
     <li data-md="">
-     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-23">offset path</a>s with contain are unclosed intervals.</p>
+     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-22">offset path</a>s with contain are unclosed intervals.</p>
     <li data-md="">
-     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-24">offset path</a>s without contain are unbounded rays.</p>
+     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-23">offset path</a>s without contain are unbounded rays.</p>
     <li data-md="">
      <p>All basic CSS shapes are closed loops.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-25">Offset path</a>s (including references to SVG Paths) are closed loops only if the final command
+     <p><a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-24">Offset path</a>s (including references to SVG Paths) are closed loops only if the final command
 in the path list is a closepath command ("z" or "Z"), otherwise they are unclosed intervals.</p>
     <li data-md="">
      <p>References to SVG circles, ellipses, images, polygons and rects are closed loops.</p>
     <li data-md="">
      <p>References to SVG lines and polylines are unclosed intervals.</p>
    </ul>
-   <p>To determine the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="used-offset-distance">used offset distance</dfn> for a given <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-26">offset path</a> and <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="offset-distance">offset distance</dfn>:</p>
+   <p>To determine the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="used-offset-distance">used offset distance</dfn> for a given <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-25">offset path</a> and <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="offset-distance">offset distance</dfn>:</p>
    <div class="switch">
     <ol>
      <li data-md="">
-      <p>Let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="total-length">total length</dfn> be the total length of <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-27">offset path</a> with all
+      <p>Let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="total-length">total length</dfn> be the total length of <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-26">offset path</a> with all
 sub-paths.</p>
      <li data-md="">
       <dl>
@@ -700,19 +701,19 @@ sub-paths.</p>
      <li data-md="">
       <dl>
        <dt data-md="">
-        <p>If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-28">offset path</a> is an unbounded ray:</p>
+        <p>If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-27">offset path</a> is an unbounded ray:</p>
        <dd data-md="">
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-1">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-2">offset distance</a>.</p>
        <dt data-md="">
-        <p>Otherwise if <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-29">offset path</a> is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> path with contain:</p>
+        <p>Otherwise if <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-28">offset path</a> is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> path with contain:</p>
        <dd data-md="">
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-2">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-3">offset distance</a>, clamped by −<var>upper bound</var> and <var>upper bound</var>.</p>
        <dt data-md="">
-        <p>If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-30">offset path</a> is any other unclosed interval:</p>
+        <p>If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-29">offset path</a> is any other unclosed interval:</p>
        <dd data-md="">
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-3">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-4">offset distance</a> clamped by 0 and <var>upper bound</var>.</p>
        <dt data-md="">
-        <p>Otherwise <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-31">offset path</a> is a closed loop:</p>
+        <p>Otherwise <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-30">offset path</a> is a closed loop:</p>
        <dd data-md="">
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-4">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-5">offset distance</a> modulus <var>upper bound</var>.</p>
       </dl>
@@ -839,7 +840,7 @@ sub-paths.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -887,7 +888,7 @@ unless the element is an SVG element without an associated CSS layout box.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -912,7 +913,7 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
 		A percentage for the vertical offset is relative to the height of the content box
 		area of the element.
 		For example, with a value pair of '100%, 0%', an anchor point is on the upper right corner of the element.
-      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a>
+      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a>
       <dd>A length value gives a length offset from the upper left corner of the element’s content area.
      </dl>
    </dl>
@@ -1109,14 +1110,15 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
     <dt><dfn class="dfn-paneled css" data-dfn-for="offset-rotate" data-dfn-type="value" data-export="" id="valdef-offset-rotate-auto">auto</dfn>
     <dd>Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-6">offset-distance</a> is animated) by 
 the angle of the direction 
-(i.e., directional tangent vector) of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a>. 
+(i.e., directional tangent vector) of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a>, relative to the positive x-axis.
 If specified in combination with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added
 to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-4">auto</a>.
+    <p class="note" role="note">Note: For ray paths, the rotation implied by <a class="property" data-link-type="propdesc">auto</a> is 90 degrees less than the ray’s bearing <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>.</p>
     <dt><dfn class="dfn-paneled css" data-dfn-for="offset-rotate" data-dfn-type="value" data-export="" id="valdef-offset-rotate-reverse">reverse</dfn>
     <dd>
      Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-7">offset-distance</a> is animated) by
  the angle of the direction 
-(i.e., directional tangent vector) of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a> plus 180 degrees. 
+(i.e., directional tangent vector) of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a>, relative to the positive x-axis, plus 180 degrees.
 	If specified in combination with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added 
 	to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-1">reverse</a>. 
      <p class="note" role="note">This is the same as specifying <span class="css">auto 180deg</span>. </p>
@@ -1166,8 +1168,8 @@ on the path.</p>
 	rotated by a fixed amount of degree.</figcaption>
     </div>
    </div>
-   <div class="example" id="example-ede8e56c">
-    <a class="self-link" href="#example-ede8e56c"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-7">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-4">reverse</a> works specified in combination 
+   <div class="example" id="example-fc2976e0">
+    <a class="self-link" href="#example-fc2976e0"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-7">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-4">reverse</a> work when specified in combination
 with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
 The computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-8">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-5">reverse</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
@@ -1206,12 +1208,12 @@ The computed value of <a class="production css" data-link-type="type" href="http
   <span class="nn">#item5</span> <span class="p">{</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">225</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">90%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> auto <span class="m">-90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> <span class="n">reverse</span> <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="nn">#item6</span> <span class="p">{</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">path</span><span class="o">:</span> <span class="n">ray</span><span class="p">(</span><span class="m">-45</span><span class="n">deg</span><span class="p">);</span>
     <span class="n">offset</span><span class="o">-</span><span class="n">distance</span><span class="o">:</span> <span class="m">90%</span><span class="p">;</span>
-    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> auto <span class="m">90</span><span class="n">deg</span><span class="p">;</span>
+    <span class="n">offset</span><span class="o">-</span><span class="n">rotate</span><span class="o">:</span> <span class="n">reverse</span> <span class="m">-90</span><span class="n">deg</span><span class="p">;</span>
   <span class="p">}</span>
 <span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
@@ -1275,7 +1277,7 @@ Omitted values are set to their initial values.</p>
      <li data-md="">
       <p>Create a supplemental transformation matrix <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="t">T</dfn> for the local coordinate system of the element.</p>
      <li data-md="">
-      <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="p">P</dfn> be the point at the <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-5">used offset distance</a> along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-32">offset path</a>.</p>
+      <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="p">P</dfn> be the point at the <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-5">used offset distance</a> along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-31">offset path</a>.</p>
      <li data-md="">
       <p>Find the translation of the box such that its anchor point is placed at <a data-link-type="dfn" href="#p" id="ref-for-p-1">P</a>, and apply that to <a data-link-type="dfn" href="#t" id="ref-for-t-1">T</a>.</p>
      <li data-md="">
@@ -1418,9 +1420,9 @@ Omitted values are set to their initial values.</p>
      <li><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[css-containment-3]</a> defines the following terms:
+    <a data-link-type="biblio">[css-containment-1]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a>
+     <li><a href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-images-3]</a> defines the following terms:
@@ -1529,8 +1531,8 @@ Omitted values are set to their initial values.</p>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-css-containment-3">[CSS-CONTAINMENT-3]
-   <dd>CSS Containment Module Level 3 URL: <a href="https://drafts.csswg.org/css-containment-3/">https://drafts.csswg.org/css-containment-3/</a>
+   <dt id="biblio-css-containment-1">[CSS-CONTAINMENT-1]
+   <dd>CSS Containment Module Level 1 URL: <a href="https://drafts.csswg.org/css-containment-1/">https://drafts.csswg.org/css-containment-1/</a>
    <dt id="biblio-css3color">[CSS3COLOR]
    <dd>Tantek Çelik; Chris Lilley; David Baron. <a href="https://www.w3.org/TR/css3-color">CSS Color Module Level 3</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/css3-color">https://www.w3.org/TR/css3-color</a>
   </dl>
@@ -1637,10 +1639,10 @@ Omitted values are set to their initial values.</p>
   <aside class="dfn-panel" data-for="offset-path">
    <b><a href="#offset-path">#offset-path</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-offset-path-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-offset-path-2">(2)</a> <a href="#ref-for-offset-path-3">(3)</a> <a href="#ref-for-offset-path-4">(4)</a> <a href="#ref-for-offset-path-5">(5)</a> <a href="#ref-for-offset-path-6">(6)</a> <a href="#ref-for-offset-path-7">(7)</a> <a href="#ref-for-offset-path-8">(8)</a> <a href="#ref-for-offset-path-9">(9)</a> <a href="#ref-for-offset-path-10">(10)</a> <a href="#ref-for-offset-path-11">(11)</a> <a href="#ref-for-offset-path-12">(12)</a> <a href="#ref-for-offset-path-13">(13)</a> <a href="#ref-for-offset-path-14">(14)</a> <a href="#ref-for-offset-path-15">(15)</a> <a href="#ref-for-offset-path-16">(16)</a>
-    <li><a href="#ref-for-offset-path-17">4.2. Position on the path: The offset-distance property</a> <a href="#ref-for-offset-path-18">(2)</a> <a href="#ref-for-offset-path-19">(3)</a> <a href="#ref-for-offset-path-20">(4)</a>
-    <li><a href="#ref-for-offset-path-21">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-offset-path-22">(2)</a> <a href="#ref-for-offset-path-23">(3)</a> <a href="#ref-for-offset-path-24">(4)</a> <a href="#ref-for-offset-path-25">(5)</a> <a href="#ref-for-offset-path-26">(6)</a> <a href="#ref-for-offset-path-27">(7)</a> <a href="#ref-for-offset-path-28">(8)</a> <a href="#ref-for-offset-path-29">(9)</a> <a href="#ref-for-offset-path-30">(10)</a> <a href="#ref-for-offset-path-31">(11)</a>
-    <li><a href="#ref-for-offset-path-32">4.7.1. Calculating the path transform</a>
+    <li><a href="#ref-for-offset-path-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-offset-path-2">(2)</a> <a href="#ref-for-offset-path-3">(3)</a> <a href="#ref-for-offset-path-4">(4)</a> <a href="#ref-for-offset-path-5">(5)</a> <a href="#ref-for-offset-path-6">(6)</a> <a href="#ref-for-offset-path-7">(7)</a> <a href="#ref-for-offset-path-8">(8)</a> <a href="#ref-for-offset-path-9">(9)</a> <a href="#ref-for-offset-path-10">(10)</a> <a href="#ref-for-offset-path-11">(11)</a> <a href="#ref-for-offset-path-12">(12)</a> <a href="#ref-for-offset-path-13">(13)</a> <a href="#ref-for-offset-path-14">(14)</a> <a href="#ref-for-offset-path-15">(15)</a>
+    <li><a href="#ref-for-offset-path-16">4.2. Position on the path: The offset-distance property</a> <a href="#ref-for-offset-path-17">(2)</a> <a href="#ref-for-offset-path-18">(3)</a> <a href="#ref-for-offset-path-19">(4)</a>
+    <li><a href="#ref-for-offset-path-20">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-offset-path-21">(2)</a> <a href="#ref-for-offset-path-22">(3)</a> <a href="#ref-for-offset-path-23">(4)</a> <a href="#ref-for-offset-path-24">(5)</a> <a href="#ref-for-offset-path-25">(6)</a> <a href="#ref-for-offset-path-26">(7)</a> <a href="#ref-for-offset-path-27">(8)</a> <a href="#ref-for-offset-path-28">(9)</a> <a href="#ref-for-offset-path-29">(10)</a> <a href="#ref-for-offset-path-30">(11)</a>
+    <li><a href="#ref-for-offset-path-31">4.7.1. Calculating the path transform</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="initial-position">

--- a/motion-1/images/geometry-box.svg
+++ b/motion-1/images/geometry-box.svg
@@ -6,5 +6,5 @@
 </style>
 <rect class="boundary" x="10" y="22" width="440" height="240" />
 <rect class="path" x="10" y="22" width="440" height="240" rx="80" ry="80" />
-<rect class="placed" x="68" y="0" width="44" height="44" />
+<rect class="placed" x="68" y="11" width="44" height="22" />
 </svg>


### PR DESCRIPTION
Creating a stacking context is not dependent on the reference resolving successfully.

The meaning of offset-rotate 'auto' has also been clarified: the direction of the path, relative to the positive x-axis. The "positive x-axis" terminology is copied from SVG:
https://www.w3.org/TR/SVG11/painting.html#OrientAttribute
https://www.w3.org/TR/SVG11/implnote.html#PathElementImplementationNotes

Example 12 now makes use of both 'auto' and 'reverse'.

resolves #65