### PR TITLE
[motion] Group the parameters of ray

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -123,6 +123,11 @@ and its ancestors have no transformation applied.
 Values have the following meanings:
 
 <dl dfn-for="offset-path">
+
+<dt>ray( [ <<angle>> && <<size>>? && contain? ] )</dt>
+<dd>
+
+<dl>
 <dt><<angle>></dt>
 <dd>
 	The <a>offset path</a> is a line segment that starts from the position of the element and proceeds in the
@@ -143,8 +148,10 @@ Values have the following meanings:
 	for consistency with other CSS specifications such as [[!CSS3VAL]], <<angle>> value.
 	(as the preceding line doesn't have "x axis position")
 	</p>
-	<dl>
-	
+</dd>
+</dl>
+
+<dl>
 		<dt><<size>></dt>
 		<dd>Decides the position of the end point of the path.
 			When the offset of the element on the <a>offset path</a> is specified with <<percentage>>, 
@@ -180,13 +187,17 @@ Values have the following meanings:
 			the position of the element specified with <var>closest-side</var> remains unchanged.
 			</p>
 		</dd>
+</dl>
 
+<dl>
 		<dt><dfn>contain</dfn></dt>
 		<dd>
 			Makes the element don't have clipped area by altering the length of the <a>offset path</a> when the part of the element on the <a>offset path</a> is outside the edge of the containing block.
 			If the element is larger than the containing block, the element would be positioned where it has the smallest clipped area by modifying the <a>offset path</a>’s length with reducing the least amount.
 
 		</dd>
+</dl>
+
 		<div class='example'>
 		Here are some examples.
 		The first example shows that some parts of elements are outside of the <a>offset path</a>.
@@ -233,7 +244,6 @@ Values have the following meanings:
 			<figcaption>'offset-path' with 'contain'</figcaption>
 		</div>
 		</div>
-	</dl>
 </dd>
 
 <dt><<basic-shape>> || <<geometry-box>></dt>

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@ editors
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-23">23 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-18">18 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -309,7 +309,7 @@ editors
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -461,12 +461,15 @@ E.g. A rotation of <span class="css">0 degree</span> points to the upper side of
 and its ancestors have no transformation applied.</p>
    <p>Values have the following meanings:</p>
    <dl>
-    <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>
+    <dt>ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> &amp;&amp; <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a>? &amp;&amp; contain? ] )
     <dd>
-      The <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-3">offset path</a> is a line segment that starts from the position of the element and proceeds in the
+     <dl>
+      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>
+      <dd>
+        The <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-3">offset path</a> is a line segment that starts from the position of the element and proceeds in the
 	direction defined by the specified <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. As with <a href="https://www.w3.org/TR/css3-images/#gradients">CSS gradients</a>, <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> values are interpreted
 	as bearing angles, with <a class="property" data-link-type="propdesc">0deg</a> pointing up and positive angles representing clockwise rotation. 
-     <p class="note" role="note">Note: Defining an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-4">offset path</a> with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, 
+       <p class="note" role="note">Note: Defining an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-4">offset path</a> with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, 
 	the element can be positioned with the used of polar coordinates.
 	The polar coordinate system is a two-dimensional coordinate system in which each point on a plane
 	is determined by a distance from a fixed point and an angle from a fixed line.
@@ -478,6 +481,7 @@ and its ancestors have no transformation applied.</p>
 	of the x axis, but we consider the polar axis as the positive direction of the y axis 
 	for consistency with other CSS specifications such as <a data-link-type="biblio" href="#biblio-css3val">[CSS3VAL]</a>, <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> value.
 	(as the preceding line doesn’t have "x axis position") </p>
+     </dl>
      <dl>
       <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a>
       <dd>
@@ -506,11 +510,14 @@ and its ancestors have no transformation applied.</p>
 			the containing block, the closest side takes the edge that the initial position 
 			is on. If the <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> as a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#percentage-value">&lt;percentage></a> changes,
 			the position of the element specified with <var>closest-side</var> remains unchanged. </p>
+     </dl>
+     <dl>
       <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-contain">contain<a class="self-link" href="#offset-path-contain"></a></dfn>
       <dd> Makes the element don’t have clipped area by altering the length of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-7">offset path</a> when the part of the element on the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-8">offset path</a> is outside the edge of the containing block.
 			If the element is larger than the containing block, the element would be positioned where it has the smallest clipped area by modifying the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-9">offset path</a>’s length with reducing the least amount. 
-      <div class="example" id="example-c1b71b23">
-       <a class="self-link" href="#example-c1b71b23"></a> Here are some examples.
+     </dl>
+     <div class="example" id="example-c1b71b23">
+      <a class="self-link" href="#example-c1b71b23"></a> Here are some examples.
 		The first example shows that some parts of elements are outside of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-10">offset path</a>. 
 <pre class="lang-css highlight"><span class="nt">#redBox </span><span class="p">{</span>
   <span class="k">background-color</span><span class="p">:</span> red<span class="p">;</span>
@@ -527,11 +534,11 @@ and its ancestors have no transformation applied.</p>
   offset-distance: 100%;
 }
 </pre>
-       <div class="figure">
-         <img alt="An image of elements positioned without contain" src="images/offset_distance_without_contain.png" style="width: 200px;"> 
-        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-2">offset-path</a> without <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a></figcaption>
-       </div>
-       <p>In the second example, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a> is given to the <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-3">offset-path</a> value of each element
+      <div class="figure">
+        <img alt="An image of elements positioned without contain" src="images/offset_distance_without_contain.png" style="width: 200px;"> 
+       <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-2">offset-path</a> without <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a></figcaption>
+      </div>
+      <p>In the second example, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a> is given to the <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-3">offset-path</a> value of each element
 		to avoid overflowing.</p>
 <pre class="lang-css highlight"><span class="nt">#redBox </span><span class="p">{</span>
   <span class="k">background-color</span><span class="p">:</span> red<span class="p">;</span>
@@ -547,12 +554,11 @@ and its ancestors have no transformation applied.</p>
   offset-path: ray(180deg contain);
 }
 </pre>
-       <div class="figure">
-         <img alt="An image of elements positioned with contain" src="images/offset_distance_with_contain.png" style="width: 200px;"> 
-        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-4">offset-path</a> with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a></figcaption>
-       </div>
+      <div class="figure">
+        <img alt="An image of elements positioned with contain" src="images/offset_distance_with_contain.png" style="width: 200px;"> 
+       <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-4">offset-path</a> with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a></figcaption>
       </div>
-     </dl>
+     </div>
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> || <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a>
     <dd>
      The <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-11">offset path</a> is a basic shape as specified in CSS Shapes <a data-link-type="biblio" href="#biblio-css-shapes">[CSS-SHAPES]</a>.
@@ -646,7 +652,7 @@ or is non-existent is ignored. No <a data-link-type="dfn" href="#offset-path" id
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -839,7 +845,7 @@ sub-paths.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -887,7 +893,7 @@ unless the element is an SVG element without an associated CSS layout box.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -912,7 +918,7 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
 		A percentage for the vertical offset is relative to the height of the content box
 		area of the element.
 		For example, with a value pair of '100%, 0%', an anchor point is on the upper right corner of the element.
-      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a>
+      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a>
       <dd>A length value gives a length offset from the upper left corner of the element’s content area.
      </dl>
    </dl>
@@ -1418,9 +1424,9 @@ Omitted values are set to their initial values.</p>
      <li><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[css-containment-3]</a> defines the following terms:
+    <a data-link-type="biblio">[css-containment-1]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a>
+     <li><a href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-images-3]</a> defines the following terms:
@@ -1529,8 +1535,8 @@ Omitted values are set to their initial values.</p>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-css-containment-3">[CSS-CONTAINMENT-3]
-   <dd>CSS Containment Module Level 3 URL: <a href="https://drafts.csswg.org/css-containment-3/">https://drafts.csswg.org/css-containment-3/</a>
+   <dt id="biblio-css-containment-1">[CSS-CONTAINMENT-1]
+   <dd>CSS Containment Module Level 1 URL: <a href="https://drafts.csswg.org/css-containment-1/">https://drafts.csswg.org/css-containment-1/</a>
    <dt id="biblio-css3color">[CSS3COLOR]
    <dd>Tantek Çelik; Chris Lilley; David Baron. <a href="https://www.w3.org/TR/css3-color">CSS Color Module Level 3</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/css3-color">https://www.w3.org/TR/css3-color</a>
   </dl>


### PR DESCRIPTION
The descriptions of \<angle\>, \<size\> and 'contain' are now grouped under a single entry for ray.

This addresses the third editorial comment in #72