### PR TITLE
[motion] Airplane rotation example shows unrotated airplane

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -769,14 +769,15 @@ Note: The rotation described here does not override or replace any rotation defi
 the 'transform' property.
 
 <div class="example">
-The following examples use the shape of a plane. 
-The red dot in the middle of the shape indicates the origin of the shape.
+The following examples use the shape of a plane.
+The red dot in the middle of the shape indicates the anchor of the shape.
+When no offset properties are set, the shape is not translated or rotated along the path.
 <div class=figure>
-	<img src="images/plane.svg" width="160" height="140" alt="Shape with its origin">
-	<figcaption>A red dot in the middle of a plane shape indicates the shape's origin.</figcaption>
+	<img src="images/offset-initial.svg" width="470" height="120" alt="Path without offset">
+	<figcaption>A black plane at the beginning of the path, with no offset properties set.</figcaption>
 </div>
 
-When the shape's point of origin is placed at different positions along the path and 
+When the shape's anchor is placed at different positions along the path and
 'offset-rotate' is '0deg', the shape is not rotated.
 <div class=figure>
 	<img src="images/offset-rotate-none.svg" width="470" height="120" alt="Path without rotation">
@@ -784,9 +785,9 @@ When the shape's point of origin is placed at different positions along the path
 	rotation transforms.</figcaption>
 </div>
 
-If the 'offset-rotate' property is set to ''auto'', the shape's point of origin is 
-placed at different positions along the path.
-The shape is rotated based on the gradient at the current position and faces 
+If the 'offset-rotate' property is set to ''auto'', and the shape's anchor is
+placed at different positions along the path,
+the shape is rotated based on the gradient at the current position and faces 
 the direction of the path at this position.
 
 <div class=figure>

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -290,7 +290,7 @@ editors
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-23">23 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-18">18 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -309,7 +309,7 @@ editors
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -529,9 +529,9 @@ and its ancestors have no transformation applied.</p>
 </pre>
        <div class="figure">
          <img alt="An image of elements positioned without contain" src="images/offset_distance_without_contain.png" style="width: 200px;"> 
-        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-2">offset-path</a> without <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a></figcaption>
+        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-2">offset-path</a> without <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a></figcaption>
        </div>
-       <p>In the second example, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a> is given to the <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-3">offset-path</a> value of each element
+       <p>In the second example, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a> is given to the <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-3">offset-path</a> value of each element
 		to avoid overflowing.</p>
 <pre class="lang-css highlight"><span class="nt">#redBox </span><span class="p">{</span>
   <span class="k">background-color</span><span class="p">:</span> red<span class="p">;</span>
@@ -549,7 +549,7 @@ and its ancestors have no transformation applied.</p>
 </pre>
        <div class="figure">
          <img alt="An image of elements positioned with contain" src="images/offset_distance_with_contain.png" style="width: 200px;"> 
-        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-4">offset-path</a> with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a></figcaption>
+        <figcaption><a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-4">offset-path</a> with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a></figcaption>
        </div>
       </div>
      </dl>
@@ -646,7 +646,7 @@ or is non-existent is ignored. No <a data-link-type="dfn" href="#offset-path" id
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -839,7 +839,7 @@ sub-paths.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -887,7 +887,7 @@ unless the element is an SVG element without an associated CSS layout box.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -912,7 +912,7 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
 		A percentage for the vertical offset is relative to the height of the content box
 		area of the element.
 		For example, with a value pair of '100%, 0%', an anchor point is on the upper right corner of the element.
-      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | vmin | cm | pc | pixel unit | vi | in | rem | q | vh | ex | pt | vw | vmax | ic | mm">&lt;length></a>
+      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | q">&lt;length></a>
       <dd>A length value gives a length offset from the upper left corner of the element’s content area.
      </dl>
    </dl>
@@ -1128,22 +1128,23 @@ either one of the keywords.
    </dl>
    <p class="note" role="note">Note: The rotation described here does not override or replace any rotation defined by
 the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">transform</a> property.</p>
-   <div class="example" id="example-ab96805c">
-    <a class="self-link" href="#example-ab96805c"></a> The following examples use the shape of a plane. 
-The red dot in the middle of the shape indicates the origin of the shape. 
+   <div class="example" id="example-03564bd1">
+    <a class="self-link" href="#example-03564bd1"></a> The following examples use the shape of a plane.
+The red dot in the middle of the shape indicates the anchor of the shape.
+When no offset properties are set, the shape is not translated or rotated along the path. 
     <div class="figure">
-      <img alt="Shape with its origin" height="140" src="images/plane.svg" width="160"> 
-     <figcaption>A red dot in the middle of a plane shape indicates the shape’s origin.</figcaption>
+      <img alt="Path without offset" height="120" src="images/offset-initial.svg" width="470"> 
+     <figcaption>A black plane at the beginning of the path, with no offset properties set.</figcaption>
     </div>
-    <p>When the shape’s point of origin is placed at different positions along the path and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-2">offset-rotate</a> is <a class="property" data-link-type="propdesc">0deg</a>, the shape is not rotated.</p>
+    <p>When the shape’s anchor is placed at different positions along the path and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-2">offset-rotate</a> is <a class="property" data-link-type="propdesc">0deg</a>, the shape is not rotated.</p>
     <div class="figure">
       <img alt="Path without rotation" height="120" src="images/offset-rotate-none.svg" width="470"> 
      <figcaption>A black plane at different positions on a blue dotted path without 
 	rotation transforms.</figcaption>
     </div>
-    <p>If the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-3">offset-rotate</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-6">auto</a>, the shape’s point of origin is
-placed at different positions along the path.
-The shape is rotated based on the gradient at the current position and faces 
+    <p>If the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-3">offset-rotate</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-6">auto</a>, and the shape’s anchor is
+placed at different positions along the path,
+the shape is rotated based on the gradient at the current position and faces 
 the direction of the path at this position.</p>
     <div class="figure">
       <img alt="Path with auto rotation" height="120" src="images/offset-rotate-auto.svg" width="470"> 
@@ -1418,9 +1419,9 @@ Omitted values are set to their initial values.</p>
      <li><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[css-containment-3]</a> defines the following terms:
+    <a data-link-type="biblio">[css-containment-1]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-containment-3/#propdef-contain">contain</a>
+     <li><a href="https://drafts.csswg.org/css-containment-1/#propdef-contain">contain</a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-images-3]</a> defines the following terms:
@@ -1529,8 +1530,8 @@ Omitted values are set to their initial values.</p>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-css-containment-3">[CSS-CONTAINMENT-3]
-   <dd>CSS Containment Module Level 3 URL: <a href="https://drafts.csswg.org/css-containment-3/">https://drafts.csswg.org/css-containment-3/</a>
+   <dt id="biblio-css-containment-1">[CSS-CONTAINMENT-1]
+   <dd>CSS Containment Module Level 1 URL: <a href="https://drafts.csswg.org/css-containment-1/">https://drafts.csswg.org/css-containment-1/</a>
    <dt id="biblio-css3color">[CSS3COLOR]
    <dd>Tantek Çelik; Chris Lilley; David Baron. <a href="https://www.w3.org/TR/css3-color">CSS Color Module Level 3</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/css3-color">https://www.w3.org/TR/css3-color</a>
   </dl>

--- a/motion-1/images/offset-initial.svg
+++ b/motion-1/images/offset-initial.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="470" height="120">
+<style type="text/css">
+.path{fill:none;stroke:#00AEEF;stroke-width:3;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:0.4997,4.9973;}
+.text{font-family:'MyriadPro-Regular';font-size:12;}
+</style>
+<defs>
+<path id="plane" d="M15.1-6.2H3.4l-6.3-9.9c1.8-0.3,5.4-1.5,5.4-3.6s-4.8-3.6-6.3-3.6h-3.9l-4.5-6.9h-8.4l2.4,6.9h-0.3v7.2h3l3.6,9.9h-15.9l-6.6-6.6h-4.8l5.7,9.6v7.8l-5.7,9.6h4.8l6.6-6.6h15.9l-3.6,9.6h-3v7.2h0.3l-2.4,6.9h8.7l4.5-6.9h3.9c1.5,0,6.3-1.5,6.3-3.6c0-1.8-3.6-3.3-5.4-3.6l6.3-9.9h11.7c3.9,0,18-2.7,18-6.9C33.1-3.5,19-6.2,15.1-6.2z"/>
+<circle id="dot" r="3" fill="red"/>
+
+
+</defs>
+<use xlink:href="#plane" transform="translate(57.8,45)"/>
+<use xlink:href="#dot" transform="translate(57.8,45)"/>
+<path class="path" d="M421.2,50C343.5,175.5,142.1-86,57.8,45"/>
+</svg>


### PR DESCRIPTION
The first airplane example in the offset-rotation section shows the placement of the airplane before any ``offset-*`` properties are applied.

Resolves #71