### PR TITLE
No rotation when path is none

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -310,7 +310,7 @@ The initial position and the initial direction for basic shapes are defined as f
 	See SVG 1.1 for more information about the initial position and initial direction [[!SVG11]].
 	</dd>
 	<dt dfn-type=value><dfn>none</dfn></dt>
-	<dd>No <a>offset path</a> gets created.</dd>
+	<dd>No <a>offset path</a> gets created. When 'offset-path' is none, 'offset-distance' and 'offset-rotate' have no effect.</dd>
 </dl>
 
 A computed value of other than ''none'' results in the creation of a <a spec="css21">stacking context</a> [[!CSS21]] 

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -7,7 +7,8 @@
   <link href="../default.css" rel="stylesheet" type="text/css">
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version 01e1da232fdaa21e9ce8535bfdf8ca7adefa84f8" name="generator">
+  <meta content="Bikeshed version b734e371910e25ac23b774dca3dea5cfc7b7fc0b" name="generator">
+  <link href="https://www.w3.org/TR/motion-1/" rel="canonical">
 <style>
   /* Style for bikeshed variant of switch/case <dl>s */
   div.switch dl > dd > ol.only {
@@ -290,7 +291,7 @@ editors
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-02">2 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-31">31 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -334,7 +335,7 @@ editors
 	W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/32061/status" rel="disclosure">public list of any patent disclosures (CSS)</a> and a <a href="http://www.w3.org/2004/01/pp-impl/19480/status" rel="disclosure">public list of any patent disclosures (SVG)</a> made in connection with the deliverables of each group;
 	these pages also include instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p>This document is governed by the <a href="http://www.w3.org/2015/Process-20150901/" id="w3c_process_revision">1 September 2015 W3C Process Document</a>. </p>
+   <p>This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -617,7 +618,7 @@ The initial position and the initial direction for basic shapes are defined as f
     <dd>References an SVG <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a> and uses its geometry as <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-13">offset path</a>.
 	See SVG 1.1 for more information about the initial position and initial direction <a data-link-type="biblio" href="#biblio-svg11">[SVG11]</a>. 
     <dt><dfn class="css" data-dfn-for="offset-path" data-dfn-type="value" data-export="" id="valdef-offset-path-none">none<a class="self-link" href="#valdef-offset-path-none"></a></dfn>
-    <dd>No <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-14">offset path</a> gets created.
+    <dd>No <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-14">offset path</a> gets created. When <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-5">offset-path</a> is none, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-4">offset-distance</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-1">offset-rotate</a> have no effect.
    </dl>
    <p>A computed value of other than <span class="css">none</span> results in the creation of a <a data-link-type="dfn" href="https://drafts.csswg.org/css21/visuren.html#x43">stacking context</a> <a data-link-type="biblio" href="#biblio-css21">[CSS21]</a> the same way that CSS <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a> <a data-link-type="biblio" href="#biblio-css3color">[CSS3COLOR]</a> does for values other than <span class="css">1</span>,
 unless the element is an SVG element without an associated CSS layout box.</p>
@@ -627,7 +628,7 @@ or is non-existent, is treated as equivalent to <span class="css">path("m 0 0")<
    <p>See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-15">offset path</a>.</p>
    <p>For SVG elements without associated CSS layout box, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#used-value">used value</a> for <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-content-box">content-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-padding-box">padding-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box">border-box</a> and <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-margin-box">margin-box</a> is <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box">fill-box</a>.</p>
    <p>For elements with associated CSS layout box, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#used-value">used value</a> for <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box">fill-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-stroke-box">stroke-box</a> and <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-view-box">view-box</a> is <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box">border-box</a>.</p>
-   <h3 class="heading settled" data-level="4.2" id="offset-distance-property"><span class="secno">4.2. </span><span class="content">Position on the path: The <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-4">offset-distance</a> property</span><a class="self-link" href="#offset-distance-property"></a></h3>
+   <h3 class="heading settled" data-level="4.2" id="offset-distance-property"><span class="secno">4.2. </span><span class="content">Position on the path: The <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-5">offset-distance</a> property</span><a class="self-link" href="#offset-distance-property"></a></h3>
    <table class="def propdef" data-link-for-hint="offset-distance">
     <tbody>
      <tr>
@@ -653,7 +654,7 @@ or is non-existent, is treated as equivalent to <span class="css">path("m 0 0")<
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | pt | cm | vh | vi | px | in | rem | lh | q | pc | ex | vmin | vw | vmax | ic | mm | rlh">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -776,7 +777,7 @@ sub-paths.</p>
     </div>
    </div>
    <div class="example" id="example-ae2df301">
-    <a class="self-link" href="#example-ae2df301"></a> This example shows a way to align elements within the polar coordinate system using <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-5">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-5">offset-distance</a>. 
+    <a class="self-link" href="#example-ae2df301"></a> This example shows a way to align elements within the polar coordinate system using <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-6">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-6">offset-distance</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span><span class="p">{</span>
     <span class="k">width</span><span class="p">:</span> <span class="mi">300</span><span class="kt">px</span><span class="p">;</span>
@@ -822,7 +823,7 @@ sub-paths.</p>
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-offset-position">offset-position</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
+      <td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-position">&lt;position></a>
      <tr>
       <th>Initial:
       <td>auto
@@ -840,7 +841,7 @@ sub-paths.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | pt | cm | vh | vi | px | in | rem | lh | q | pc | ex | vmin | vw | vmax | ic | mm | rlh">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
@@ -855,8 +856,8 @@ sub-paths.</p>
     <dd>Uses the position of the box’s anchor point
 as determined by the CSS visual formatting model
 prior to transforms or offsetting of the box. 
-    <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
-    <dd>Specifies the initial position using the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a> syntax used by <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>,
+    <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-position">&lt;position></a>
+    <dd>Specifies the initial position using the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-position">&lt;position></a> syntax used by <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>,
 with the the containing block as the positioning area
 and a dimensionless point (zero-sized box) as the object area. 
    </dl>
@@ -870,7 +871,7 @@ unless the element is an SVG element without an associated CSS layout box.</p>
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-offset-anchor">offset-anchor</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
+      <td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-position">&lt;position></a>
      <tr>
       <th>Initial:
       <td>auto
@@ -888,13 +889,13 @@ unless the element is an SVG element without an associated CSS layout box.</p>
       <td>visual
      <tr>
       <th>Computed value:
-      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | pt | cm | vh | vi | px | in | rem | lh | q | pc | ex | vmin | vw | vmax | ic | mm | rlh">&lt;length></a> the absolute value, otherwise a percentage.
+      <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
       <th>Canonical order:
       <td>per grammar
      <tr>
       <th>Animatable:
-      <td>as <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
+      <td>as <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-position">&lt;position></a>
    </table>
    <p>Defines an anchor point of the element positioned along the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a>.
 The anchor specifies the point of the element which is to be considered 
@@ -902,9 +903,9 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
    <p>Values have the following meanings:</p>
    <dl>
     <dt><var>auto</var>
-    <dd>Computes to the value from <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-2">offset-position</a>, provided <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-6">offset-path</a> is <span class="css">none</span> and <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-3">offset-position</a> is not <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-2">auto</a>. Otherwise, computes
-	to the value from <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">transform-origin</a>. When <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-3">auto</a> is given to <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-2">offset-anchor</a>, and <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-7">offset-path</a> is <span class="css">none</span>, <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-4">offset-position</a> behaves similar to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>. 
-    <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
+    <dd>Computes to the value from <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-2">offset-position</a>, provided <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-7">offset-path</a> is <span class="css">none</span> and <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-3">offset-position</a> is not <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-2">auto</a>. Otherwise, computes
+	to the value from <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">transform-origin</a>. When <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-3">auto</a> is given to <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-2">offset-anchor</a>, and <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-8">offset-path</a> is <span class="css">none</span>, <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-4">offset-position</a> behaves similar to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>. 
+    <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-position">&lt;position></a>
     <dd>
      <dl>
       <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#percentage-value">&lt;percentage></a>
@@ -913,7 +914,7 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
 		A percentage for the vertical offset is relative to the height of the content box
 		area of the element.
 		For example, with a value pair of '100%, 0%', an anchor point is on the upper right corner of the element.
-      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | advance measure | vb | ch | pt | cm | vh | vi | px | in | rem | lh | q | pc | ex | vmin | vw | vmax | ic | mm | rlh">&lt;length></a>
+      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" title="Expands to: em | vb | ch | cm | vh | vi | vw | ex | in | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a>
       <dd>A length value gives a length offset from the upper left corner of the element’s content area.
      </dl>
    </dl>
@@ -1070,7 +1071,7 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
      <figcaption>An example of 'offset-anchor: auto'</figcaption>
     </div>
    </div>
-   <h3 class="heading settled" data-level="4.5" id="offset-rotate-property"><span class="secno">4.5. </span><span class="content">Rotation at point: The <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-1">offset-rotate</a> property</span><a class="self-link" href="#offset-rotate-property"></a></h3>
+   <h3 class="heading settled" data-level="4.5" id="offset-rotate-property"><span class="secno">4.5. </span><span class="content">Rotation at point: The <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-2">offset-rotate</a> property</span><a class="self-link" href="#offset-rotate-property"></a></h3>
    <table class="def propdef" data-link-for-hint="offset-rotate">
     <tbody>
      <tr>
@@ -1108,7 +1109,7 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
    <p>Values have the following meanings:</p>
    <dl>
     <dt><dfn class="dfn-paneled css" data-dfn-for="offset-rotate" data-dfn-type="value" data-export="" id="valdef-offset-rotate-auto">auto</dfn>
-    <dd>Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-6">offset-distance</a> is animated) by 
+    <dd>Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-7">offset-distance</a> is animated) by 
 the angle of the direction 
 (i.e., directional tangent vector) of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a>, relative to the positive x-axis.
 If specified in combination with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added
@@ -1116,7 +1117,7 @@ to the computed value of <a class="css" data-link-type="maybe" href="#valdef-off
     <p class="note" role="note">Note: For ray paths, the rotation implied by <a class="property" data-link-type="propdesc">auto</a> is 90 degrees less than the ray’s bearing <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>.</p>
     <dt><dfn class="dfn-paneled css" data-dfn-for="offset-rotate" data-dfn-type="value" data-export="" id="valdef-offset-rotate-reverse">reverse</dfn>
     <dd>
-     Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-7">offset-distance</a> is animated) by
+     Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-8">offset-distance</a> is animated) by
  the angle of the direction 
 (i.e., directional tangent vector) of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a>, relative to the positive x-axis, plus 180 degrees.
 	If specified in combination with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added 
@@ -1138,13 +1139,13 @@ When no offset properties are set, the shape is not translated or rotated along 
       <img alt="Path without offset" height="120" src="images/offset-initial.svg" width="470"> 
      <figcaption>A black plane at the beginning of the path, with no offset properties set.</figcaption>
     </div>
-    <p>When the shape’s anchor is placed at different positions along the path and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-2">offset-rotate</a> is <a class="property" data-link-type="propdesc">0deg</a>, the shape is not rotated.</p>
+    <p>When the shape’s anchor is placed at different positions along the path and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-3">offset-rotate</a> is <a class="property" data-link-type="propdesc">0deg</a>, the shape is not rotated.</p>
     <div class="figure">
       <img alt="Path without rotation" height="120" src="images/offset-rotate-none.svg" width="470"> 
      <figcaption>A black plane at different positions on a blue dotted path without 
 	rotation transforms.</figcaption>
     </div>
-    <p>If the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-3">offset-rotate</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-6">auto</a>, and the shape’s anchor is
+    <p>If the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-4">offset-rotate</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-6">auto</a>, and the shape’s anchor is
 placed at different positions along the path,
 the shape is rotated based on the gradient at the current position and faces 
 the direction of the path at this position.</p>
@@ -1153,14 +1154,14 @@ the direction of the path at this position.</p>
      <figcaption>A black plane at different positions on a blue dotted path, 
 	rotated in the direction of the path.</figcaption>
     </div>
-    <p>In this example, the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-4">offset-rotate</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-3">reverse</a>.
+    <p>In this example, the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-5">offset-rotate</a> property is set to <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-3">reverse</a>.
 The plane faces the opposite direction of the path at each position on the path.</p>
     <div class="figure">
       <img alt="Path with reverse auto rotation" height="120" src="images/offset-rotate-reverse.svg" width="470"> 
      <figcaption>A black plane at different positions on a blue dotted path, 
 	rotated in the opposite direction of the path.</figcaption>
     </div>
-    <p>The last example sets the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-5">offset-rotate</a> property to <span class="css">-45deg</span>.
+    <p>The last example sets the <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-6">offset-rotate</a> property to <span class="css">-45deg</span>.
 The shape is rotated anticlockwise by 45 degree once and keeps the rotation at each position
 on the path.</p>
     <div class="figure">
@@ -1234,7 +1235,7 @@ The computed value of <a class="production css" data-link-type="type" href="http
    </div>
    <p class="issue" id="issue-5d73326d"><a class="self-link" href="#issue-5d73326d"></a> More natural names requested for <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-10">auto</a> and <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-6">reverse</a>.</p>
    <p>See the section <a href="#offset-processing">“Offset processing”</a> for
-how to process <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-6">offset-rotate</a>.</p>
+how to process <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-7">offset-rotate</a>.</p>
    <h3 class="heading settled" data-level="4.6" id="offset-shorthand"><span class="secno">4.6. </span><span class="content">Offset shorthand: The <a class="property" data-link-type="propdesc" href="#propdef-offset" id="ref-for-propdef-offset-1">offset</a> property</span><a class="self-link" href="#offset-shorthand"></a></h3>
    <table class="def propdef" data-link-for-hint="offset">
     <tbody>
@@ -1269,7 +1270,7 @@ how to process <a class="property" data-link-type="propdesc" href="#propdef-offs
       <th>Animatable:
       <td>see individual properties
    </table>
-   <p>This is a shorthand property for setting <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-5">offset-position</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-8">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-8">offset-distance</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-7">offset-rotate</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-4">offset-anchor</a>.
+   <p>This is a shorthand property for setting <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-5">offset-position</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-9">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-9">offset-distance</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-8">offset-rotate</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-4">offset-anchor</a>.
 Omitted values are set to their initial values.</p>
    <h3 class="heading settled" data-level="4.7" id="offset-processing"><span class="secno">4.7. </span><span class="content">Offset processing</span><a class="self-link" href="#offset-processing"></a></h3>
    <h4 class="heading settled" data-level="4.7.1" id="calculating-path-transform"><span class="secno">4.7.1. </span><span class="content">Calculating the path transform</span><a class="self-link" href="#calculating-path-transform"></a></h4>
@@ -1282,7 +1283,7 @@ Omitted values are set to their initial values.</p>
      <li data-md="">
       <p>Find the translation of the box such that its anchor point is placed at <a data-link-type="dfn" href="#p" id="ref-for-p-1">P</a>, and apply that to <a data-link-type="dfn" href="#t" id="ref-for-t-1">T</a>.</p>
      <li data-md="">
-      <p>Post-multiply <a data-link-type="dfn" href="#t" id="ref-for-t-2">T</a> by the rotation specified by <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-8">offset-rotate</a>.</p>
+      <p>Post-multiply <a data-link-type="dfn" href="#t" id="ref-for-t-2">T</a> by the rotation specified by <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-9">offset-rotate</a>.</p>
      <li data-md="">
       <p>Post-multiply <a data-link-type="dfn" href="#t" id="ref-for-t-3">T</a> to the local coordinate system of the element.</p>
     </ol>
@@ -1407,7 +1408,6 @@ Omitted values are set to their initial values.</p>
    <li>
     <a data-link-type="biblio">[css-backgrounds-3]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-backgrounds-3/#position">&lt;position></a>
      <li><a href="https://drafts.csswg.org/css-backgrounds-3/#background-position">background-position</a>
      <li><a href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a>
     </ul>
@@ -1474,6 +1474,7 @@ Omitted values are set to their initial values.</p>
      <li><a href="https://drafts.csswg.org/css-values-4/#mult-req">!</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">&lt;length-percentage></a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#typedef-position">&lt;position></a>
      <li><a href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#comb-one">|</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#comb-any">||</a>
@@ -1625,10 +1626,10 @@ Omitted values are set to their initial values.</p>
   <aside class="dfn-panel" data-for="propdef-offset-path">
    <b><a href="#propdef-offset-path">#propdef-offset-path</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-offset-path-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-path-2">(2)</a> <a href="#ref-for-propdef-offset-path-3">(3)</a> <a href="#ref-for-propdef-offset-path-4">(4)</a>
-    <li><a href="#ref-for-propdef-offset-path-5">4.2.1. Calculating the computed distance along a path</a>
-    <li><a href="#ref-for-propdef-offset-path-6">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-propdef-offset-path-7">(2)</a>
-    <li><a href="#ref-for-propdef-offset-path-8">4.6. Offset shorthand: The offset property</a>
+    <li><a href="#ref-for-propdef-offset-path-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-path-2">(2)</a> <a href="#ref-for-propdef-offset-path-3">(3)</a> <a href="#ref-for-propdef-offset-path-4">(4)</a> <a href="#ref-for-propdef-offset-path-5">(5)</a>
+    <li><a href="#ref-for-propdef-offset-path-6">4.2.1. Calculating the computed distance along a path</a>
+    <li><a href="#ref-for-propdef-offset-path-7">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-propdef-offset-path-8">(2)</a>
+    <li><a href="#ref-for-propdef-offset-path-9">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="offset-path">
@@ -1655,11 +1656,11 @@ Omitted values are set to their initial values.</p>
   <aside class="dfn-panel" data-for="propdef-offset-distance">
    <b><a href="#propdef-offset-distance">#propdef-offset-distance</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-offset-distance-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-distance-2">(2)</a> <a href="#ref-for-propdef-offset-distance-3">(3)</a>
-    <li><a href="#ref-for-propdef-offset-distance-4">4.2. Position on the path: The offset-distance property</a>
-    <li><a href="#ref-for-propdef-offset-distance-5">4.2.1. Calculating the computed distance along a path</a>
-    <li><a href="#ref-for-propdef-offset-distance-6">4.5. Rotation at point: The offset-rotate property</a> <a href="#ref-for-propdef-offset-distance-7">(2)</a>
-    <li><a href="#ref-for-propdef-offset-distance-8">4.6. Offset shorthand: The offset property</a>
+    <li><a href="#ref-for-propdef-offset-distance-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-distance-2">(2)</a> <a href="#ref-for-propdef-offset-distance-3">(3)</a> <a href="#ref-for-propdef-offset-distance-4">(4)</a>
+    <li><a href="#ref-for-propdef-offset-distance-5">4.2. Position on the path: The offset-distance property</a>
+    <li><a href="#ref-for-propdef-offset-distance-6">4.2.1. Calculating the computed distance along a path</a>
+    <li><a href="#ref-for-propdef-offset-distance-7">4.5. Rotation at point: The offset-rotate property</a> <a href="#ref-for-propdef-offset-distance-8">(2)</a>
+    <li><a href="#ref-for-propdef-offset-distance-9">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="used-offset-distance">
@@ -1699,9 +1700,10 @@ Omitted values are set to their initial values.</p>
   <aside class="dfn-panel" data-for="propdef-offset-rotate">
    <b><a href="#propdef-offset-rotate">#propdef-offset-rotate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-offset-rotate-1">4.5. Rotation at point: The offset-rotate property</a> <a href="#ref-for-propdef-offset-rotate-2">(2)</a> <a href="#ref-for-propdef-offset-rotate-3">(3)</a> <a href="#ref-for-propdef-offset-rotate-4">(4)</a> <a href="#ref-for-propdef-offset-rotate-5">(5)</a> <a href="#ref-for-propdef-offset-rotate-6">(6)</a>
-    <li><a href="#ref-for-propdef-offset-rotate-7">4.6. Offset shorthand: The offset property</a>
-    <li><a href="#ref-for-propdef-offset-rotate-8">4.7.1. Calculating the path transform</a>
+    <li><a href="#ref-for-propdef-offset-rotate-1">4.1. Define a path: The offset-path property</a>
+    <li><a href="#ref-for-propdef-offset-rotate-2">4.5. Rotation at point: The offset-rotate property</a> <a href="#ref-for-propdef-offset-rotate-3">(2)</a> <a href="#ref-for-propdef-offset-rotate-4">(3)</a> <a href="#ref-for-propdef-offset-rotate-5">(4)</a> <a href="#ref-for-propdef-offset-rotate-6">(5)</a> <a href="#ref-for-propdef-offset-rotate-7">(6)</a>
+    <li><a href="#ref-for-propdef-offset-rotate-8">4.6. Offset shorthand: The offset property</a>
+    <li><a href="#ref-for-propdef-offset-rotate-9">4.7.1. Calculating the path transform</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valdef-offset-rotate-auto">


### PR DESCRIPTION
When 'offset-path' is none, 'offset-distance' and 'offset-rotate' have
no effect.

See discussion in #64
