### PR TITLE
[geometry] Use union instead of overload for DOMMatrix/DOMMatrixReadO…

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -20,7 +20,7 @@ Editor: Rik Cabanier, Adobe Systems Inc., cabanier@adobe.com
 Abstract: This specification provides basic geometric interfaces to represent points, rectangles, quadrilaterals and transformation matrices that can be used by other modules or specifications.
 !Issues list: <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=FXTF&amp;component=Geometry&amp;resolution=---">Bugzilla</a> (<a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=FXTF&amp;component=Geometry">file a bug</a>)
 Test Suite: http://test.csswg.org/suites/geometry-1_dev/nightly-unstable/
-Use <i> Autolinks: yes
+Use <i> Autolinks: no
 Ignored Vars: a, b, f, Point object, m44, e, m42, quad1, m41, stringifier, point object, m12, c, transformPoint, m21, d, m22, quad2, sz
 </pre>
 
@@ -142,7 +142,7 @@ steps:
 <ol>
   <li>Create a new <a interface>DOMPoint</a> <var>point</var> initialized to <a attribute for=DOMPoint>x</a>, <a attribute for=DOMPoint>y</a>, <a attribute for=DOMPoint>z</a> and <a attribute for=DOMPoint>w</a> of the current point.</li>
   <li>Let <var>matrix object</var> be the result of invoking <a>create a <code>DOMMatrix</code> from the dictionary</a> <var>matrix</var>.
-  <li><i>Post-multiply</i> <var>point</var> with <var>matrix object</var>.</li>
+  <li><a>Post-multiply</a> <var>point</var> with <var>matrix object</var>.</li>
   <li>Return <var>point</var>.</li>
 </ol>
 <p><a>matrixTransform()</a> does not modify the current <a interface>DOMPointReadOnly</a> object and returns a new <a interface>DOMPoint</a> object.

--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -147,7 +147,7 @@ steps:
 </ol>
 <p><a>matrixTransform()</a> does not modify the current <a interface>DOMPointReadOnly</a> object and returns a new <a interface>DOMPoint</a> object.
 <div class='example'>
-  <p>In this example the method <a method>matrixTransform()</a> on <var>point</var> is called with a <a interface>DOMMatrix</a> argument <var>matrix</var>.</p>
+  <p>In this example the method {{DOMPointReadOnly/matrixTransform()}} on <var>point</var> is called with a <a interface>DOMMatrix</a> argument <var>matrix</var>.</p>
   <pre><code>var point = new DOMPoint(5, 4);
 var matrix = new DOMMatrix([2, 0, 0, 2, 10, 10]);
 var transformedPoint = point.matrixTransform(matrix);
@@ -172,11 +172,11 @@ Rectangles have the following properties:
   </dd>
   <dt><dfn for=rectangle id=rectangle-x-coordinate>x coordinate</dfn></dt>
   <dd>
-    The horizontal distance between the viewport's left edge and the rectangle's <a>origin</a>.
+    The horizontal distance between the viewport's left edge and the rectangle's <a for=rectangle>origin</a>.
   </dd>
   <dt><dfn for=rectangle id=rectangle-y-coordinate>y coordinate</dfn></dt>
   <dd>
-    The vertical distance between the viewport's top edge and the rectangle's <a>origin</a>.
+    The vertical distance between the viewport's top edge and the rectangle's <a for=rectangle>origin</a>.
   </dd>
   <dt><dfn for=rectangle id=rectangle-width-dimension>width dimension</dfn></dt>
   <dd>
@@ -436,9 +436,7 @@ In the following sections, terms have the following meaning:
 </dl>
 
 <pre class='idl'>
-[Constructor,
- Constructor(DOMString transformList),
- Constructor(sequence&lt;unrestricted double> numberSequence),
+[Constructor(optional (DOMString or sequence&lt;unrestricted double>) init = [1, 0, 0, 1, 0, 0]),
  Exposed=(Window,Worker)]
 interface DOMMatrixReadOnly {
     [NewObject] static DOMMatrixReadOnly fromMatrix(optional DOMMatrixInit other);
@@ -510,9 +508,7 @@ interface DOMMatrixReadOnly {
                         serializer = { attribute };
 };
 
-[Constructor,
- Constructor(DOMString transformList),
- Constructor(sequence&lt;unrestricted double> numberSequence),
+[Constructor(optional (DOMString or sequence&lt;unrestricted double>) init = [1, 0, 0, 1, 0, 0]),
  Exposed=(Window,Worker)]
 interface DOMMatrix : DOMMatrixReadOnly {
     [NewObject] static DOMMatrix fromMatrix(optional DOMMatrixInit other);
@@ -660,76 +656,77 @@ Note: This means that two ''NaN'' values are the same.
 <h3 id='dommatrix-create'>Creating DOMMatrixReadOnly and DOMMatrix objects</h3>
 
 To <dfn>create a 2d matrix</dfn> of type <var>type</var> being either {{DOMMatrixReadOnly}} or {{DOMMatrix}},
-with a sequence <var>numberSequence</var> of 6 elements, follow these steps:
+with a sequence <var>init</var> of 6 elements, follow these steps:
 
 1. Let <var>matrix</var> be a new instance of <var>type</var>.
-1. Set <a>m11 element</a>, <a>m12 element</a>, <a>m21 element</a>, <a>m22 element</a>, <a>m41 element</a> and <a>m42 element</a> to the values of <var>numberSequence</var> in order starting with the first value.
+1. Set <a>m11 element</a>, <a>m12 element</a>, <a>m21 element</a>, <a>m22 element</a>, <a>m41 element</a> and <a>m42 element</a> to the values of <var>init</var> in order starting with the first value.
 1. Set <a>m31 element</a>, <a>m32 element</a>, <a>m13 element</a>, <a>m23 element</a>, <a>m43 element</a>, <a>m14 element</a>, <a>m24 element</a> and <a>m34 element</a> to ''0''.
 1. Set <a>m33 element</a> and <a>m44 element</a> to ''1''.
 1. Set <a>is2D</a> to <code>true</code>.
 1. Return <var>matrix</var>
 
 To <dfn>create a 3d matrix</dfn> with <var>type</var> being either {{DOMMatrixReadOnly}} or {{DOMMatrix}},
-with a sequence <var>numberSequence</var> of 16 elements, follow these steps:
+with a sequence <var>init</var> of 16 elements, follow these steps:
 
 1. Let <var>matrix</var> be a new instance of <var>type</var>.
-1. Set <a>m11 element</a> to <a>m44 element</a> to the values of <var>numberSequence</var> in column-major order.
+1. Set <a>m11 element</a> to <a>m44 element</a> to the values of <var>init</var> in column-major order.
 1. Set <a>is2D</a> to <code>false</code>.
 1. Return <var>matrix</var>
 
-The <dfn dfn-type=constructor dfn-for=DOMMatrixReadOnly><code>DOMMatrixReadOnly()</code></dfn> and
-the <dfn dfn-type=constructor dfn-for=DOMMatrix><code>DOMMatrix()</code></dfn> constructors, when
-invoked with no argument, must run the following steps:
-
-<ol>
-  <li>Return the result of invoking <a>create a 2d matrix</a> of type {{DOMMatrixReadOnly}} or
-  {{DOMMatrix}} as appropriate, with the sequence [''1'', ''0'', ''0'', ''1'', ''0'', ''0''].</li>
-</ol>
-
-The <dfn dfn-type=constructor dfn-for=DOMMatrixReadOnly><code>DOMMatrixReadOnly(<var>transformList</var>)</code></dfn> and
-the <dfn dfn-type=constructor dfn-for=DOMMatrix><code>DOMMatrix(<var>transformList</var>)</code></dfn> constructors, when invoked with a {{DOMString}} argument, must follow these steps:
-
-<ol>
-  <li>If <var>transformList</var> is the empty string, set it to the string "<code lt>matrix(1, 0,
-  0, 1, 0, 0)</code>".</li>
-  <li>Parse <var>transformList</var> into <var>parsedValue</var> by following the syntax description in
-  “<a href=https://drafts.csswg.org/css-transforms-1/#svg-syntax>Syntax of the SVG ‘transform’
-  attribute</a>” [[!CSS3-TRANSFORMS]] to a <<transform-list>> or the keyword ''transform/none''. If
-  parsing is not successful, or any <<transform-function>> has <<length>> values without <a
-  spec='css-values'>absolute length</a> units<!--For WD: <a spec='css-values-3'>absolute length
-  units</a>-->, or any keyword other than ''transform/none'' is used, throw a {{SyntaxError}}
-  exception.</li>
-  <li>If <var>parsedValue</var> is ''transform/none'', set <var>parsedValue</var> to a
-  <<transform-list>> containing a single identity matrix</li>
-  <li>Let <var>2dTransform</var> track the 2D/3D dimension status of <var>parsedValue</var>.
-    <dl class=switch>
-      <dt>If <var>parsedValue</var> consists of any <a href='https://drafts.csswg.org/css-transforms-1/#three-d-transform-functions'>3D Transform functions</a></dt>
-      <dd>Set <var>2dTransform</var> to <code>false</code>.</dd>
-      <dt>Otherwise</dt>
-      <dd>Set <var>2dTransform</var> to <code>true</code>.</dd>
-    </dl>
-  </li>
-  <li>Transform all <<transform-function>>s to 4x4 matrices by following the “<a href=https://drafts.csswg.org/css-transforms-1/#mathematical-description>Mathematical Description of Transform Functions</a>” [[!CSS3-TRANSFORMS]].</li>
-  <li>Let <var>matrix</var> be a 4x4 matrix as shown in the initial figure of this section. Post-multiply all matrices from left to right and set <var>matrix</var> to this product.</li>
-  <li>
-    <dl class=switch>
-      <dt>If <var>2dTransform</var> is set to <code>true</code></dt>
-      <dd>Return the result of invoking <a>create a 2d matrix</a> of type {{DOMMatrixReadOnly}} or {{DOMMatrix}} as appropriate, with a sequence of numbers, the values being the elements <var>m11</var>, <var>m12</var>, <var>m21</var>, <var>m22</var>, <var>m41</var> and <var>m42</var> of <var>matrix</var>.</dd>
-      <dt>If <var>2dTransform</var> is set to <code>false</code></dt>
-      <dd>Return the result of invoking <a>create a 3d matrix</a> of type {{DOMMatrixReadOnly}} or {{DOMMatrix}} as appropriate, with a sequence of numbers, the values being the 16 elements of <var>matrix</var>.</dd>
-    </dl>
-  </li>
-</ol>
-
-The <dfn dfn-type=constructor dfn-for=DOMMatrixReadOnly><code>DOMMatrixReadOnly(<var>numberSequence</var>)</code></dfn> and
-the <dfn dfn-type=constructor dfn-for=DOMMatrix><code>DOMMatrix(<var>numberSequence</var>)</code></dfn> constructors,
-when invoked with a sequence argument, must run the following steps:
+The <dfn dfn-type=constructor dfn-for=DOMMatrixReadOnly><code>DOMMatrixReadOnly(<var>init</var>)</code></dfn> and
+the <dfn dfn-type=constructor dfn-for=DOMMatrix><code>DOMMatrix(<var>init</var>)</code></dfn> constructors must follow these steps:
 
 <dl class=switch>
-  <dt>If <var>numberSequence</var> has 6 elements</dt>
-  <dd>Return the result of invoking <a>create a 2d matrix</a> of type {{DOMMatrixReadOnly}} or {{DOMMatrix}} as appropriate, with the sequence <var>numberSequence</var>.</dd>
-  <dt>If <var>numberSequence</var> has 16 elements</dt>
-  <dd>Return the result of invoking <a>create a 3d matrix</a> of type {{DOMMatrixReadOnly}} or {{DOMMatrix}} as appropriate, with the sequence <var>numberSequence</var>.</dd>
+  <dt>If <var>init</var> is a {{DOMString}}</dt>
+  <dd>
+    <ol>
+      <li>If <var>init</var> is the empty string, set it to the string
+      "<code>matrix(1, 0, 0, 1, 0, 0)</code>".</li>
+      <li>Parse <var>init</var> into <var>parsedValue</var> by following the syntax description in
+      “<a href=https://drafts.csswg.org/css-transforms-1/#svg-syntax>Syntax of the SVG ‘transform’
+      attribute</a>” [[!CSS3-TRANSFORMS]] to a <<transform-list>> or the keyword ''transform/none''.
+      If parsing is not successful, or any <<transform-function>> has <<length>> values without <a
+      spec='css-values'>absolute length</a> units<!--For WD: <a spec='css-values-3'>absolute length
+      units</a>-->, or any keyword other than ''transform/none'' is used, throw a {{SyntaxError}}
+      exception.</li>
+      <li>If <var>parsedValue</var> is ''transform/none'', set <var>parsedValue</var> to a
+      <<transform-list>> containing a single identity matrix</li>
+      <li>Let <var>2dTransform</var> track the 2D/3D dimension status of <var>parsedValue</var>.
+        <dl class=switch>
+          <dt>If <var>parsedValue</var> consists of any <a
+          href='https://drafts.csswg.org/css-transforms-1/#three-d-transform-functions'>3D Transform
+          functions</a></dt>
+          <dd>Set <var>2dTransform</var> to <code>false</code>.</dd>
+          <dt>Otherwise</dt>
+          <dd>Set <var>2dTransform</var> to <code>true</code>.</dd>
+        </dl>
+      </li>
+      <li>Transform all <<transform-function>>s to 4x4 matrices by following the “<a
+      href=https://drafts.csswg.org/css-transforms-1/#mathematical-description>Mathematical
+      Description of Transform Functions</a>” [[!CSS3-TRANSFORMS]].</li>
+      <li>Let <var>matrix</var> be a 4x4 matrix as shown in the initial figure of this section.
+      Post-multiply all matrices from left to right and set <var>matrix</var> to this product.</li>
+      <li>
+        <dl class=switch>
+          <dt>If <var>2dTransform</var> is set to <code>true</code></dt>
+          <dd>Return the result of invoking <a>create a 2d matrix</a> of type {{DOMMatrixReadOnly}}
+          or {{DOMMatrix}} as appropriate, with a sequence of numbers, the values being the elements
+          <var>m11</var>, <var>m12</var>, <var>m21</var>, <var>m22</var>, <var>m41</var> and
+          <var>m42</var> of <var>matrix</var>.</dd>
+          <dt>If <var>2dTransform</var> is set to <code>false</code></dt>
+          <dd>Return the result of invoking <a>create a 3d matrix</a> of type {{DOMMatrixReadOnly}}
+          or {{DOMMatrix}} as appropriate, with a sequence of numbers, the values being the 16
+          elements of <var>matrix</var>.</dd>
+        </dl>
+      </li>
+    </ol>
+  </dd>
+  <dt>If <var>init</var> is a sequence with 6 elements</dt>
+  <dd>Return the result of invoking <a>create a 2d matrix</a> of type {{DOMMatrixReadOnly}} or
+  {{DOMMatrix}} as appropriate, with the sequence <var>init</var>.</dd>
+  <dt>If <var>init</var> is a sequence with 16 elements</dt>
+  <dd>Return the result of invoking <a>create a 3d matrix</a> of type {{DOMMatrixReadOnly}} or
+  {{DOMMatrix}} as appropriate, with the sequence <var>init</var>.</dd>
   <dt>Otherwise</dt>
   <dd>Throw a <code>TypeError</code> exception.</dd>
 </dl>
@@ -871,7 +868,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>translateSelf()</a> transformation on <em>result</em> with the arguments <var>tx</var>, <var>ty</var>, <var>tz</var>.</li>
+      <li>Perform a {{DOMMatrix/translateSelf()}} transformation on <em>result</em> with the arguments <var>tx</var>, <var>ty</var>, <var>tz</var>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -882,7 +879,7 @@ The following methods do not modify the current matrix and return a new <a inter
       <li>Let <var>result</var> be the resulting matrix initialized to the values of the current
       matrix.</li>
 
-      <li>Perform a <a method>scaleSelf()</a> transformation on <var>result</var> with the arguments
+      <li>Perform a {{DOMMatrix/scaleSelf()}} transformation on <var>result</var> with the arguments
       <var>scaleX</var>, <var>scaleY</var>, <var>scaleZ</var>, <var>originX</var>,
       <var>originY</var>, <var>originZ</var>.</li>
 
@@ -894,7 +891,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>scale3dSelf()</a> transformation on <em>result</em> with the arguments <var>scale</var>, <var>originX</var>, <var>originY</var>, <var>originZ</var>.</li>
+      <li>Perform a {{DOMMatrix/scale3dSelf()}} transformation on <em>result</em> with the arguments <var>scale</var>, <var>originX</var>, <var>originY</var>, <var>originZ</var>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -903,7 +900,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>rotateSelf()</a> transformation on <em>result</em> with the arguments <var>rotX</var>, <var>rotY</var>, <var>rotZ</var>.</li>
+      <li>Perform a {{DOMMatrix/rotateSelf()}} transformation on <em>result</em> with the arguments <var>rotX</var>, <var>rotY</var>, <var>rotZ</var>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -912,7 +909,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>rotateFromVectorSelf()</a> transformation on <em>result</em> with the arguments <var>x</var>, <var>y</var>.</li>
+      <li>Perform a {{DOMMatrix/rotateFromVectorSelf()}} transformation on <em>result</em> with the arguments <var>x</var>, <var>y</var>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -921,7 +918,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>rotateAxisAngleSelf()</a> transformation on <em>result</em> with the arguments <var>x</var>, <var>y</var>, <var>z</var>, <var>angle</var>.</li>
+      <li>Perform a {{DOMMatrix/rotateAxisAngleSelf()}} transformation on <em>result</em> with the arguments <var>x</var>, <var>y</var>, <var>z</var>, <var>angle</var>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -930,7 +927,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>skewXSelf()</a> transformation on <em>result</em> with the argument <var>sx</var>.</li>
+      <li>Perform a {{DOMMatrix/skewXSelf()}} transformation on <em>result</em> with the argument <var>sx</var>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -939,7 +936,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>skewYSelf()</a> transformation on <em>result</em> with the argument <var>sy</var>.</li>
+      <li>Perform a {{DOMMatrix/skewYSelf()}} transformation on <em>result</em> with the argument <var>sy</var>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -948,7 +945,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>multiplySelf()</a> transformation on <em>result</em> with the argument <var>other</var>.</li>
+      <li>Perform a {{DOMMatrix/multiplySelf()}} transformation on <em>result</em> with the argument <var>other</var>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -975,7 +972,7 @@ The following methods do not modify the current matrix and return a new <a inter
   <dd>
     <ol>
       <li>Let <em>result</em> be the resulting matrix initialized to the values of the current matrix.</li>
-      <li>Perform a <a method>invertSelf()</a> transformation on <em>result</em>.</li>
+      <li>Perform a {{DOMMatrix/invertSelf()}} transformation on <em>result</em>.</li>
       <li>Return <em>result</em>.</li>
     </ol>
     <p>The current matrix is not modified.</p>
@@ -1080,7 +1077,7 @@ Note: Authors who use chained method calls are recommended to use mutable transf
   <dt><dfn>scaleSelf(<var>scaleX</var>, <var>scaleY</var>, <var>scaleZ</var>, <var>originX</var>, <var>originY</var>, <var>originZ</var>)</dfn></dt>
   <dd>
     <ol>
-      <li>Perform a <a method>translateSelf()</a> transformation on the current matrix with the arguments <var>originX</var>, <var>originY</var>, <var>originZ</var>.</li>
+      <li>Perform a {{DOMMatrix/translateSelf()}} transformation on the current matrix with the arguments <var>originX</var>, <var>originY</var>, <var>originZ</var>.</li>
 
       <li>If <var>scaleY</var> is missing, set <var>scaleY</var> to the value of
       <var>scaleX</var>.</li>
@@ -1093,7 +1090,7 @@ Note: Authors who use chained method calls are recommended to use mutable transf
 
       <li>Negate <var>originX</var>, <var>originY</var> and <var>originZ</var>.</li>
 
-      <li>Perform a <a method>translateSelf()</a> transformation on the current matrix with the
+      <li>Perform a {{DOMMatrix/translateSelf()}}</a> transformation on the current matrix with the
       arguments <var>originX</var>, <var>originY</var>, <var>originZ</var>.</li>
 
       <li>If <var>scaleZ</var> is not ''1'' or <var>originZ</var> is not ''0'', set <a>is2D</a> of
@@ -1105,9 +1102,9 @@ Note: Authors who use chained method calls are recommended to use mutable transf
   <dt><dfn>scale3dSelf(<var>scale</var>, <var>originX</var>, <var>originY</var>, <var>originZ</var>)</dfn></dt>
   <dd>
     <ol>
-      <li>Apply a <a method>translateSelf(<var>originX</var>, <var>originY</var>, <var>originZ</var>)</a> transformation to the current matrix.</li>
+      <li>Apply a {{DOMMatrix/translateSelf()}} transformation to the current matrix with the arguments <var>originX</var>, <var>originY</var>, <var>originZ</var>.</li>
       <li>Post-multiply a uniform 3D scale transformation (<a attribute>m11</a> = <a attribute>m22</a> = <a attribute>m33</a> = <em>scale</em>) on the current matrix. The 3D scale matrix is <a href="https://drafts.csswg.org/css-transforms-1/#Scale3dDefined">described</a> in CSS Transforms with <em>sx</em> = <em>sy</em> = <em>sz</em> = <em>scale</em>. [[!CSS3-TRANSFORMS]].</li>
-      <li>Apply a <a method>translateSelf(-<var>originX</var>, -<var>originY</var>, -<var>originZ</var>)</a> transformation to the current matrix.</li>
+      <li>Apply a {{DOMMatrix/translateSelf()}} transformation to the current matrix with the arguments -<var>originX</var>, -<var>originY</var>, -<var>originZ</var>.</li>
       <li>If <em>scale</em> is not ''1'', set <a>is2D</a> of the current matrix to <code>false</code>.</li>
       <li>Return the current matrix.</li>
     </ol>
@@ -1220,15 +1217,15 @@ The following changes were made since the <a href="https://www.w3.org/TR/2014/WD
   <li>Changed {{DOMMatrixReadOnly}} and {{DOMMatrix}} to be compatible with
   <code>WebKitCSSMatrix</code>:
     <ul>
-      <li>Changed <a>rotate()</a> and <a>rotateSelf()</a> arguments from (angle, originX, originY)
-      to (rotX, rotY, rotZ).
+      <li>Changed {{DOMMatrixReadOnly/rotate()}} and {{DOMMatrix/rotateSelf()}} arguments from
+      (angle, originX, originY) to (rotX, rotY, rotZ).
 
-      <li>Changed the <a>scale()</a> and <a>scaleSelf()</a> methods to be more like the previous
-      <code>scaleNonUniform()</code>/<code>scaleNonUniformSelf()</code> methods, and dropped the
-      <code>scaleNonUniform*</code> methods.
+      <li>Changed the {{DOMMatrixReadOnly/scale()}} and {{DOMMatrix/scaleSelf()}} methods to be more
+      like the previous <code>scaleNonUniform()</code>/<code>scaleNonUniformSelf()</code> methods,
+      and dropped the <code>scaleNonUniform*</code> methods.
 
       <li>Made all arguments optional for {{DOMMatrix}}/{{DOMMatrixReadOnly}} methods, except for
-      <a>setMatrixValue()</a>.
+      {{DOMMatrix/setMatrixValue()}}.
 
       <li>Changed <code>fromString()</code> static method to overloaded constructor.
 

--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -436,7 +436,7 @@ In the following sections, terms have the following meaning:
 </dl>
 
 <pre class='idl'>
-[Constructor(optional (DOMString or sequence&lt;unrestricted double>) init = [1, 0, 0, 1, 0, 0]),
+[Constructor(optional (DOMString or sequence&lt;unrestricted double>) init),
  Exposed=(Window,Worker)]
 interface DOMMatrixReadOnly {
     [NewObject] static DOMMatrixReadOnly fromMatrix(optional DOMMatrixInit other);
@@ -508,7 +508,7 @@ interface DOMMatrixReadOnly {
                         serializer = { attribute };
 };
 
-[Constructor(optional (DOMString or sequence&lt;unrestricted double>) init = [1, 0, 0, 1, 0, 0]),
+[Constructor(optional (DOMString or sequence&lt;unrestricted double>) init),
  Exposed=(Window,Worker)]
 interface DOMMatrix : DOMMatrixReadOnly {
     [NewObject] static DOMMatrix fromMatrix(optional DOMMatrixInit other);
@@ -677,6 +677,9 @@ The <dfn dfn-type=constructor dfn-for=DOMMatrixReadOnly><code>DOMMatrixReadOnly(
 the <dfn dfn-type=constructor dfn-for=DOMMatrix><code>DOMMatrix(<var>init</var>)</code></dfn> constructors must follow these steps:
 
 <dl class=switch>
+  <dt>If <var>init</var> is omitted</dt>
+  <dd>Return the result of invoking <a>create a 2d matrix</a> of type {{DOMMatrixReadOnly}} or
+   {{DOMMatrix}} as appropriate, with the sequence [''1'', ''0'', ''0'', ''1'', ''0'', ''0''].</dd>
   <dt>If <var>init</var> is a {{DOMString}}</dt>
   <dd>
     <ol>


### PR DESCRIPTION
…nly constructors

This changes behavior of passing `undefined` as argument to use a
default value of [1, 0, 0, 1, 0, 0] instead of the string
"undefined".

Fixes https://github.com/w3c/fxtf-drafts/issues/135.

Tests: https://github.com/w3c/web-platform-tests/issues/5719