### PR TITLE
[geometry] Do not expose CSS parser in workers for DOMMatrix

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -569,7 +569,7 @@ interface DOMMatrix : DOMMatrixReadOnly {
     DOMMatrix skewYSelf(optional unrestricted double sy = 0);
     DOMMatrix invertSelf();
 
-    DOMMatrix setMatrixValue(DOMString transformList);
+    [Exposed=Window] DOMMatrix setMatrixValue(DOMString transformList);
 };
 
 dictionary DOMMatrixInit {
@@ -683,6 +683,8 @@ the <dfn dfn-type=constructor dfn-for=DOMMatrix><code>DOMMatrix(<var>init</var>)
   <dt>If <var>init</var> is a {{DOMString}}</dt>
   <dd>
     <ol>
+      <li>If <a>current global object</a> is not a {{Window}} object, then throw a {{TypeError}}
+      exception.</li>
       <li>If <var>init</var> is the empty string, set it to the string
       "<code>matrix(1, 0, 0, 1, 0, 0)</code>".</li>
       <li>Parse <var>init</var> into <var>parsedValue</var> by following the syntax description in


### PR DESCRIPTION
Annotate setMatrixValue with [Exposed=Window] and throw TypeError
when DOMMatrix/DOMMatrixReadOnly is constructed with a string
if the current global is not a Window.

Fixes #122.

Tests: https://github.com/w3c/web-platform-tests/pull/5769