### PR TITLE
[geometry] Annotate DOMMatrix's immutable methods with [NewObject]

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -491,40 +491,41 @@ interface DOMMatrixReadOnly {
     readonly attribute boolean isIdentity;
 
     // Immutable transform methods
-    DOMMatrix translate(optional unrestricted double tx = 0,
-                        optional unrestricted double ty = 0,
-                        optional unrestricted double tz = 0);
-    DOMMatrix scale(optional unrestricted double scaleX = 1,
-                    optional unrestricted double scaleY,
-                    optional unrestricted double scaleZ = 1,
-                    optional unrestricted double originX = 0,
-                    optional unrestricted double originY = 0,
-                    optional unrestricted double originZ = 0);
-    DOMMatrix scale3d(optional unrestricted double scale = 1,
-                      optional unrestricted double originX = 0,
-                      optional unrestricted double originY = 0,
-                      optional unrestricted double originZ = 0);
-    DOMMatrix rotate(optional unrestricted double rotX = 0,
-                     optional unrestricted double rotY,
-                     optional unrestricted double rotZ);
-    DOMMatrix rotateFromVector(optional unrestricted double x = 0,
-                               optional unrestricted double y = 0);
-    DOMMatrix rotateAxisAngle(optional unrestricted double x = 0,
-                              optional unrestricted double y = 0,
-                              optional unrestricted double z = 0,
-                              optional unrestricted double angle = 0);
-    DOMMatrix skewX(optional unrestricted double sx = 0);
-    DOMMatrix skewY(optional unrestricted double sy = 0);
-    DOMMatrix multiply(optional DOMMatrixInit other);
-    DOMMatrix flipX();
-    DOMMatrix flipY();
-    DOMMatrix inverse();
+    [NewObject] DOMMatrix translate(optional unrestricted double tx = 0,
+                                    optional unrestricted double ty = 0,
+                                    optional unrestricted double tz = 0);
+    [NewObject] DOMMatrix scale(optional unrestricted double scaleX = 1,
+                                optional unrestricted double scaleY,
+                                optional unrestricted double scaleZ = 1,
+                                optional unrestricted double originX = 0,
+                                optional unrestricted double originY = 0,
+                                optional unrestricted double originZ = 0);
+    [NewObject] DOMMatrix scale3d(optional unrestricted double scale = 1,
+                                  optional unrestricted double originX = 0,
+                                  optional unrestricted double originY = 0,
+                                  optional unrestricted double originZ = 0);
+    [NewObject] DOMMatrix rotate(optional unrestricted double rotX = 0,
+                                 optional unrestricted double rotY,
+                                 optional unrestricted double rotZ);
+    [NewObject] DOMMatrix rotateFromVector(optional unrestricted double x = 0,
+                                           optional unrestricted double y = 0);
+    [NewObject] DOMMatrix rotateAxisAngle(optional unrestricted double x = 0,
+                                          optional unrestricted double y = 0,
+                                          optional unrestricted double z = 0,
+                                          optional unrestricted double angle = 0);
+    [NewObject] DOMMatrix skewX(optional unrestricted double sx = 0);
+    [NewObject] DOMMatrix skewY(optional unrestricted double sy = 0);
+    [NewObject] DOMMatrix multiply(optional DOMMatrixInit other);
+    [NewObject] DOMMatrix flipX();
+    [NewObject] DOMMatrix flipY();
+    [NewObject] DOMMatrix inverse();
 
-    DOMPoint            transformPoint(optional DOMPointInit point);
-    Float32Array        toFloat32Array();
-    Float64Array        toFloat64Array();
-                        stringifier;
-                        serializer = { attribute };
+    [NewObject] DOMPoint transformPoint(optional DOMPointInit point);
+    [NewObject] Float32Array toFloat32Array();
+    [NewObject] Float64Array toFloat64Array();
+
+    stringifier;
+    serializer = { attribute };
 };
 
 [Constructor(optional (DOMString or sequence&lt;unrestricted double>) init),


### PR DESCRIPTION
This should be editorial. It is a bit unclear from the definitions
of toFloat32Array() and toFloat64Array() if they could return the
same value, but it appears Chromium and Gecko return new values.

Tests: https://github.com/w3c/web-platform-tests/pull/5862

Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=29541