### PR TITLE
[motion] Define 'sides' value for ray size.

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -97,7 +97,7 @@ ISSUE: Add more details and examples.
 
 <pre class='propdef'>
 Name: offset-path
-Value: none | ray( [ <<angle>> && <<size>>? && contain? ] ) <br> | <<path()>> | <<url>> | [ <<basic-shape>> || <<geometry-box>> ]
+Value: none | ray( [ <<angle>> && <<size>> && contain? ] ) <br> | <<path()>> | <<url>> | [ <<basic-shape>> || <<geometry-box>> ]
 Initial: none
 Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Inherited: no
@@ -124,7 +124,7 @@ Values have the following meanings:
 
 <dl dfn-for="offset-path">
 
-<dt>ray( [ <<angle>> && <<size>>? && contain? ] )</dt>
+<dt>ray( [ <<angle>> && <<size>> && contain? ] )</dt>
 <dd>
 
 <dl>
@@ -153,16 +153,11 @@ Values have the following meanings:
 
 <dl>
 		<dt><<size>></dt>
-		<dd>Decides the position of the end point of the path.
-			When the offset of the element on the <a>offset path</a> is specified with <<percentage>>, 
-			it needs to guarantee the constant calculated value regardless of <<angle>>. 
-			To do that, <<size>> gives a distance between the start point and the end point of the <a>offset path</a>.
+		<dd>Decides the path length used when 'offset-distance' is expressed as a percentage, using the distance to the containing box. For <<size>> values other than <var>sides</var>, the path length is independent of <<angle>>.
 
 			It is defined as
 
-			&nbsp;<b>&lt;size&gt;</b> = [ closest-side | closest-corner | farthest-side | farthest-corner ]
-
-			If omitted it defaults to <var>closest-side</var>.
+			&nbsp;<b>&lt;size&gt;</b> = [ closest-side | closest-corner | farthest-side | farthest-corner | sides ]
 
 			<dl>
 				<dt><dfn>closest-side</dfn></dt>
@@ -180,12 +175,13 @@ Values have the following meanings:
 				<dt><dfn>farthest-corner</dfn></dt>
 				<dd>The distance is measured between the initial position and the farthest corner
 				of the box from it.</dd>
+
+				<dt><dfn>sides</dfn></dt>
+				<dd>The distance is measured between the initial position and the intersection of the ray with the box. If the initial position is not within the box, the distance is 0.</dd>
 			</dl>
 			<p class='note'>Note: When the initial position is on one of the edges of
 			the containing block, the closest side takes the edge that the initial position 
-			is on. If the 'offset-distance' as a <<percentage>> changes,
-			the position of the element specified with <var>closest-side</var> remains unchanged.
-			</p>
+			is on, and thus the path length used for percentage 'offset-distance' values is 0.</p>
 		</dd>
 </dl>
 

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -7,7 +7,7 @@
   <link href="../default.css" rel="stylesheet" type="text/css">
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version 5bd73bb15eb04ad9f7d1a57f012e9ee6eca5a765" name="generator">
+  <meta content="Bikeshed version 19325e1a3d427dec9961fd38c89c65a206603f18" name="generator">
   <link href="https://www.w3.org/TR/motion-1/" rel="canonical">
 <style>
   /* Style for bikeshed variant of switch/case <dl>s */
@@ -291,7 +291,7 @@ editors
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-03">3 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-13">13 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -299,7 +299,7 @@ editors
      <dt>Latest published version:
      <dd><a href="https://www.w3.org/TR/motion-1/">https://www.w3.org/TR/motion-1/</a>
      <dt>Previous Versions:
-     <dd><a href="https://www.w3.org/TR/2015/WD-motion-1-20150409/" rel="previous">https://www.w3.org/TR/2015/WD-motion-1-20150409/</a>
+     <dd><a href="https://www.w3.org/TR/2015/WD-motion-1-20150409/" rel="prev">https://www.w3.org/TR/2015/WD-motion-1-20150409/</a>
      <dt>Issue Tracking:
      <dd><a href="#issues-index">Inline In Spec</a>
      <dd><span><a href="https://github.com/w3c/fxtf-drafts/labels/motion-1">GitHub Issues</a></span>
@@ -423,7 +423,7 @@ editors
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-offset-path">offset-path</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> contain<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> ] ) <br> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="function">&lt;path()></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value">&lt;url></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any">||</a> <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> ]
+      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> contain<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> ] ) <br> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="function">&lt;path()></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value">&lt;url></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any">||</a> <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> ]
      <tr>
       <th>Initial:
       <td>none
@@ -462,7 +462,7 @@ E.g. A rotation of <span class="css">0 degree</span> points to the upper side of
 and its ancestors have no transformation applied.</p>
    <p>Values have the following meanings:</p>
    <dl>
-    <dt>ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> &amp;&amp; <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a>? &amp;&amp; contain? ] )
+    <dt>ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> &amp;&amp; <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a> &amp;&amp; contain? ] )
     <dd>
      <dl>
       <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>
@@ -486,13 +486,9 @@ and its ancestors have no transformation applied.</p>
      <dl>
       <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a>
       <dd>
-       Decides the position of the end point of the path.
-			When the offset of the element on the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-5">offset path</a> is specified with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#percentage-value">&lt;percentage></a>, 
-			it needs to guarantee the constant calculated value regardless of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
-			To do that, <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a> gives a distance between the start point and the end point of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-6">offset path</a>. 
+       Decides the path length used when <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> is expressed as a percentage, using the distance to the containing box. For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a> values other than <var>sides</var>, the path length is independent of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
        <p>It is defined as</p>
-       <p> <b>&lt;size></b> = [ closest-side | closest-corner | farthest-side | farthest-corner ]</p>
-       <p>If omitted it defaults to <var>closest-side</var>.</p>
+       <p> <b>&lt;size></b> = [ closest-side | closest-corner | farthest-side | farthest-corner | sides ]</p>
        <dl>
         <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-closest-side">closest-side<a class="self-link" href="#offset-path-closest-side"></a></dfn>
         <dd>The distance is measured between the initial position and the closest side
@@ -506,20 +502,21 @@ and its ancestors have no transformation applied.</p>
         <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-farthest-corner">farthest-corner<a class="self-link" href="#offset-path-farthest-corner"></a></dfn>
         <dd>The distance is measured between the initial position and the farthest corner
 				of the box from it.
+        <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-sides">sides<a class="self-link" href="#offset-path-sides"></a></dfn>
+        <dd>The distance is measured between the initial position and the intersection of the ray with the box. If the initial position is not within the box, the distance is 0.
        </dl>
        <p class="note" role="note">Note: When the initial position is on one of the edges of
 			the containing block, the closest side takes the edge that the initial position 
-			is on. If the <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> as a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#percentage-value">&lt;percentage></a> changes,
-			the position of the element specified with <var>closest-side</var> remains unchanged. </p>
+			is on, and thus the path length used for percentage <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-4">offset-distance</a> values is 0.</p>
      </dl>
      <dl>
       <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-contain">contain<a class="self-link" href="#offset-path-contain"></a></dfn>
-      <dd> Makes the element don’t have clipped area by altering the length of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-7">offset path</a> when the part of the element on the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-8">offset path</a> is outside the edge of the containing block.
-			If the element is larger than the containing block, the element would be positioned where it has the smallest clipped area by modifying the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-9">offset path</a>’s length with reducing the least amount. 
+      <dd> Makes the element don’t have clipped area by altering the length of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-5">offset path</a> when the part of the element on the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-6">offset path</a> is outside the edge of the containing block.
+			If the element is larger than the containing block, the element would be positioned where it has the smallest clipped area by modifying the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-7">offset path</a>’s length with reducing the least amount. 
      </dl>
      <div class="example" id="example-c1b71b23">
       <a class="self-link" href="#example-c1b71b23"></a> Here are some examples.
-		The first example shows that some parts of elements are outside of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-10">offset path</a>. 
+		The first example shows that some parts of elements are outside of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-8">offset path</a>. 
 <pre class="lang-css highlight"><span class="nt">#redBox </span><span class="p">{</span>
   <span class="k">background-color</span><span class="p">:</span> red<span class="p">;</span>
   <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
@@ -562,7 +559,7 @@ and its ancestors have no transformation applied.</p>
      </div>
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> || <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a>
     <dd>
-     The <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-11">offset path</a> is a basic shape as specified in CSS Shapes <a data-link-type="biblio" href="#biblio-css-shapes">[CSS-SHAPES]</a>.
+     The <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-9">offset path</a> is a basic shape as specified in CSS Shapes <a data-link-type="biblio" href="#biblio-css-shapes">[CSS-SHAPES]</a>.
 The initial position and the initial direction for basic shapes are defined as follows: 
      <dl>
       <dt><a class="production css" data-link-type="function" href="https://drafts.csswg.org/css-shapes-1/#funcdef-circle">&lt;circle()></a>
@@ -585,7 +582,7 @@ The initial position and the initial direction for basic shapes are defined as f
      </dl>
      <p>If <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> is supplied without a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a>, the initial position is the left end of the top horizontal line, immediately to the right of any <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a> arc, and the initial direction is to the right.</p>
      <div class="example" id="example-c7cc0c3f">
-      <a class="self-link" href="#example-c7cc0c3f"></a> This example shows how &lt;geometry-box> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-12">offset path</a> works in combination with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a>. 
+      <a class="self-link" href="#example-c7cc0c3f"></a> This example shows how &lt;geometry-box> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-10">offset path</a> works in combination with <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span><span class="p">{</span>
     <span class="k">width</span><span class="p">:</span> <span class="mi">500</span><span class="kt">px</span><span class="p">;</span>
@@ -615,20 +612,20 @@ The initial position and the initial direction for basic shapes are defined as f
 		The path data string must be conform to the grammar and parsing rules of SVG 1.1 <a data-link-type="biblio" href="#biblio-svg11">[SVG11]</a>.
 		The initial position is defined by the first “move to” argument in the path string. For the initial direction follow SVG 1.1 <a data-link-type="biblio" href="#biblio-svg11">[SVG11]</a>. 
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value">&lt;url></a>
-    <dd>References an SVG <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a> and uses its geometry as <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-13">offset path</a>.
+    <dd>References an SVG <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a> and uses its geometry as <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-11">offset path</a>.
 	See SVG 1.1 for more information about the initial position and initial direction <a data-link-type="biblio" href="#biblio-svg11">[SVG11]</a>. 
     <dt><dfn class="css" data-dfn-for="offset-path" data-dfn-type="value" data-export="" id="valdef-offset-path-none">none<a class="self-link" href="#valdef-offset-path-none"></a></dfn>
-    <dd>No <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-14">offset path</a> gets created. When <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-5">offset-path</a> is none, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-4">offset-distance</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-1">offset-rotate</a> have no effect.
+    <dd>No <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-12">offset path</a> gets created. When <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-5">offset-path</a> is none, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-5">offset-distance</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-1">offset-rotate</a> have no effect.
    </dl>
    <p>A computed value of other than <span class="css">none</span> results in the creation of a <a data-link-type="dfn" href="https://drafts.csswg.org/css21/visuren.html#x43">stacking context</a> <a data-link-type="biblio" href="#biblio-css21">[CSS21]</a> the same way that CSS <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a> <a data-link-type="biblio" href="#biblio-css3color">[CSS3COLOR]</a> does for values other than <span class="css">1</span>,
 unless the element is an SVG element without an associated CSS layout box.</p>
    <p>A reference that fails to download, is not a reference to an SVG <a data-link-type="dfn" href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">shape element</a> element,
 or is non-existent, is treated as equivalent to <span class="css">path("m 0 0")</span>.</p>
    <p class="note" role="note">Note: This is a zero length path with <a href="https://www.w3.org/TR/SVG11/implnote.html#PathElementImplementationNotes">directionality</a> aligned with the positive x-axis.</p>
-   <p>See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-15">offset path</a>.</p>
+   <p>See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-13">offset path</a>.</p>
    <p>For SVG elements without associated CSS layout box, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#used-value">used value</a> for <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-content-box">content-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-padding-box">padding-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box">border-box</a> and <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-margin-box">margin-box</a> is <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box">fill-box</a>.</p>
    <p>For elements with associated CSS layout box, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#used-value">used value</a> for <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box">fill-box</a>, <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-stroke-box">stroke-box</a> and <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-view-box">view-box</a> is <a class="css" data-link-type="value" href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box">border-box</a>.</p>
-   <h3 class="heading settled" data-level="4.2" id="offset-distance-property"><span class="secno">4.2. </span><span class="content">Position on the path: The <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-5">offset-distance</a> property</span><a class="self-link" href="#offset-distance-property"></a></h3>
+   <h3 class="heading settled" data-level="4.2" id="offset-distance-property"><span class="secno">4.2. </span><span class="content">Position on the path: The <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-6">offset-distance</a> property</span><a class="self-link" href="#offset-distance-property"></a></h3>
    <table class="def propdef" data-link-for-hint="offset-distance">
     <tbody>
      <tr>
@@ -662,37 +659,37 @@ or is non-existent, is treated as equivalent to <span class="css">path("m 0 0")<
       <th>Animatable:
       <td>yes
    </table>
-   <p>Specifies the position of the element as a distance along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-16">offset path</a>.</p>
+   <p>Specifies the position of the element as a distance along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-14">offset path</a>.</p>
    <dl>
     <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">&lt;length-percentage></a>
     <dd>
-     Specifies the distance from the initial position of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-17">offset path</a> to the position of the box’s anchor point. 
-     <p>Percentages are relative to the length of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-18">offset path</a>—<wbr>that is, the distance between 
-the initial position and the end position of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-19">offset path</a>.</p>
+     Specifies the distance from the initial position of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-15">offset path</a> to the position of the box’s anchor point. 
+     <p>Percentages are relative to the length of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-16">offset path</a>—<wbr>that is, the distance between 
+the initial position and the end position of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-17">offset path</a>.</p>
     <p></p>
    </dl>
    <h4 class="heading settled" data-level="4.2.1" id="calculating-the-computed-distance-along-a-path"><span class="secno">4.2.1. </span><span class="content">Calculating the computed distance along a path</span><a class="self-link" href="#calculating-the-computed-distance-along-a-path"></a></h4>
-   <p>Processing the distance along an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-20">offset path</a> operates differently depending upon the nature of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-21">offset path</a>:</p>
+   <p>Processing the distance along an <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-18">offset path</a> operates differently depending upon the nature of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-19">offset path</a>:</p>
    <ul>
     <li data-md="">
-     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-22">offset path</a>s with contain are unclosed intervals.</p>
+     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-20">offset path</a>s with contain are unclosed intervals.</p>
     <li data-md="">
-     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-23">offset path</a>s without contain are unbounded rays.</p>
+     <p>References to <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-21">offset path</a>s without contain are unbounded rays.</p>
     <li data-md="">
      <p>All basic CSS shapes are closed loops.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-24">Offset path</a>s (including references to SVG Paths) are closed loops only if the final command
+     <p><a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-22">Offset path</a>s (including references to SVG Paths) are closed loops only if the final command
 in the path list is a closepath command ("z" or "Z"), otherwise they are unclosed intervals.</p>
     <li data-md="">
      <p>References to SVG circles, ellipses, images, polygons and rects are closed loops.</p>
     <li data-md="">
      <p>References to SVG lines and polylines are unclosed intervals.</p>
    </ul>
-   <p>To determine the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="used-offset-distance">used offset distance</dfn> for a given <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-25">offset path</a> and <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="offset-distance">offset distance</dfn>:</p>
+   <p>To determine the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="used-offset-distance">used offset distance</dfn> for a given <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-23">offset path</a> and <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="offset-distance">offset distance</dfn>:</p>
    <div class="switch">
     <ol>
      <li data-md="">
-      <p>Let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="total-length">total length</dfn> be the total length of <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-26">offset path</a> with all
+      <p>Let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="total-length">total length</dfn> be the total length of <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-24">offset path</a> with all
 sub-paths.</p>
      <li data-md="">
       <dl>
@@ -705,16 +702,16 @@ sub-paths.</p>
       </dl>
      <li data-md="">
       <dl>
-       <dt data-md="">If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-27">offset path</a> is an unbounded ray:
+       <dt data-md="">If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-25">offset path</a> is an unbounded ray:
        <dd data-md="">
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-1">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-2">offset distance</a>.</p>
-       <dt data-md="">Otherwise if <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-28">offset path</a> is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> path with contain:
+       <dt data-md="">Otherwise if <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-26">offset path</a> is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> path with contain:
        <dd data-md="">
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-2">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-3">offset distance</a>, clamped by −<var>upper bound</var> and <var>upper bound</var>.</p>
-       <dt data-md="">If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-29">offset path</a> is any other unclosed interval:
+       <dt data-md="">If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-27">offset path</a> is any other unclosed interval:
        <dd data-md="">
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-3">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-4">offset distance</a> clamped by 0 and <var>upper bound</var>.</p>
-       <dt data-md="">Otherwise <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-30">offset path</a> is a closed loop:
+       <dt data-md="">Otherwise <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-28">offset path</a> is a closed loop:
        <dd data-md="">
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-4">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-5">offset distance</a> modulus <var>upper bound</var>.</p>
       </dl>
@@ -777,7 +774,7 @@ sub-paths.</p>
     </div>
    </div>
    <div class="example" id="example-ae2df301">
-    <a class="self-link" href="#example-ae2df301"></a> This example shows a way to align elements within the polar coordinate system using <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-6">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-6">offset-distance</a>. 
+    <a class="self-link" href="#example-ae2df301"></a> This example shows a way to align elements within the polar coordinate system using <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-6">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-7">offset-distance</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span><span class="p">{</span>
     <span class="k">width</span><span class="p">:</span> <span class="mi">300</span><span class="kt">px</span><span class="p">;</span>
@@ -1109,7 +1106,7 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
    <p>Values have the following meanings:</p>
    <dl>
     <dt><dfn class="dfn-paneled css" data-dfn-for="offset-rotate" data-dfn-type="value" data-export="" id="valdef-offset-rotate-auto">auto</dfn>
-    <dd>Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-7">offset-distance</a> is animated) by 
+    <dd>Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-8">offset-distance</a> is animated) by 
 the angle of the direction 
 (i.e., directional tangent vector) of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a>, relative to the positive x-axis.
 If specified in combination with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added
@@ -1117,7 +1114,7 @@ to the computed value of <a class="css" data-link-type="maybe" href="#valdef-off
     <p class="note" role="note">Note: For ray paths, the rotation implied by <a class="property" data-link-type="propdesc">auto</a> is 90 degrees less than the ray’s bearing <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>.</p>
     <dt><dfn class="dfn-paneled css" data-dfn-for="offset-rotate" data-dfn-type="value" data-export="" id="valdef-offset-rotate-reverse">reverse</dfn>
     <dd>
-     Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-8">offset-distance</a> is animated) by
+     Indicates that the object is rotated (over time if <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-9">offset-distance</a> is animated) by
  the angle of the direction 
 (i.e., directional tangent vector) of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a>, relative to the positive x-axis, plus 180 degrees.
 	If specified in combination with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, the computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added 
@@ -1269,7 +1266,7 @@ how to process <a class="property" data-link-type="propdesc" href="#propdef-offs
       <th>Animatable:
       <td>see individual properties
    </table>
-   <p>This is a shorthand property for setting <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-5">offset-position</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-9">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-9">offset-distance</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-8">offset-rotate</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-4">offset-anchor</a>.
+   <p>This is a shorthand property for setting <a class="property" data-link-type="propdesc" href="#propdef-offset-position" id="ref-for-propdef-offset-position-5">offset-position</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-9">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-10">offset-distance</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-rotate" id="ref-for-propdef-offset-rotate-8">offset-rotate</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-anchor" id="ref-for-propdef-offset-anchor-4">offset-anchor</a>.
 Omitted values are set to their initial values.</p>
    <h3 class="heading settled" data-level="4.7" id="offset-processing"><span class="secno">4.7. </span><span class="content">Offset processing</span><a class="self-link" href="#offset-processing"></a></h3>
    <h4 class="heading settled" data-level="4.7.1" id="calculating-path-transform"><span class="secno">4.7.1. </span><span class="content">Calculating the path transform</span><a class="self-link" href="#calculating-path-transform"></a></h4>
@@ -1278,7 +1275,7 @@ Omitted values are set to their initial values.</p>
      <li data-md="">
       <p>Create a supplemental transformation matrix <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="t">T</dfn> for the local coordinate system of the element.</p>
      <li data-md="">
-      <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="p">P</dfn> be the point at the <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-5">used offset distance</a> along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-31">offset path</a>.</p>
+      <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="p">P</dfn> be the point at the <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-5">used offset distance</a> along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-29">offset path</a>.</p>
      <li data-md="">
       <p>Find the translation of the box such that its anchor point is placed at <a data-link-type="dfn" href="#p" id="ref-for-p-1">P</a>, and apply that to <a data-link-type="dfn" href="#t" id="ref-for-t-1">T</a>.</p>
      <li data-md="">
@@ -1398,6 +1395,7 @@ Omitted values are set to their initial values.</p>
    <li><a href="#p">P</a><span>, in §4.7.1</span>
    <li><a href="#funcdef-offset-path-path">path()</a><span>, in §4.1</span>
    <li><a href="#valdef-offset-rotate-reverse">reverse</a><span>, in §4.5</span>
+   <li><a href="#offset-path-sides">sides</a><span>, in §4.1</span>
    <li><a href="#t">T</a><span>, in §4.7.1</span>
    <li><a href="#total-length">total length</a><span>, in §4.2.1</span>
    <li><a href="#used-offset-distance">used offset distance</a><span>, in §4.2.1</span>
@@ -1545,7 +1543,7 @@ Omitted values are set to their initial values.</p>
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-offset-path">offset-path</a>
-      <td>none | ray( [ &lt;angle> &amp;&amp; &lt;size>? &amp;&amp; contain? ] )  | &lt;path()> | &lt;url> | [ &lt;basic-shape> || &lt;geometry-box> ]
+      <td>none | ray( [ &lt;angle> &amp;&amp; &lt;size> &amp;&amp; contain? ] )  | &lt;path()> | &lt;url> | [ &lt;basic-shape> || &lt;geometry-box> ]
       <td>none
       <td>transformable elements
       <td>no
@@ -1629,10 +1627,10 @@ Omitted values are set to their initial values.</p>
   <aside class="dfn-panel" data-for="offset-path">
    <b><a href="#offset-path">#offset-path</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-offset-path-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-offset-path-2">(2)</a> <a href="#ref-for-offset-path-3">(3)</a> <a href="#ref-for-offset-path-4">(4)</a> <a href="#ref-for-offset-path-5">(5)</a> <a href="#ref-for-offset-path-6">(6)</a> <a href="#ref-for-offset-path-7">(7)</a> <a href="#ref-for-offset-path-8">(8)</a> <a href="#ref-for-offset-path-9">(9)</a> <a href="#ref-for-offset-path-10">(10)</a> <a href="#ref-for-offset-path-11">(11)</a> <a href="#ref-for-offset-path-12">(12)</a> <a href="#ref-for-offset-path-13">(13)</a> <a href="#ref-for-offset-path-14">(14)</a> <a href="#ref-for-offset-path-15">(15)</a>
-    <li><a href="#ref-for-offset-path-16">4.2. Position on the path: The offset-distance property</a> <a href="#ref-for-offset-path-17">(2)</a> <a href="#ref-for-offset-path-18">(3)</a> <a href="#ref-for-offset-path-19">(4)</a>
-    <li><a href="#ref-for-offset-path-20">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-offset-path-21">(2)</a> <a href="#ref-for-offset-path-22">(3)</a> <a href="#ref-for-offset-path-23">(4)</a> <a href="#ref-for-offset-path-24">(5)</a> <a href="#ref-for-offset-path-25">(6)</a> <a href="#ref-for-offset-path-26">(7)</a> <a href="#ref-for-offset-path-27">(8)</a> <a href="#ref-for-offset-path-28">(9)</a> <a href="#ref-for-offset-path-29">(10)</a> <a href="#ref-for-offset-path-30">(11)</a>
-    <li><a href="#ref-for-offset-path-31">4.7.1. Calculating the path transform</a>
+    <li><a href="#ref-for-offset-path-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-offset-path-2">(2)</a> <a href="#ref-for-offset-path-3">(3)</a> <a href="#ref-for-offset-path-4">(4)</a> <a href="#ref-for-offset-path-5">(5)</a> <a href="#ref-for-offset-path-6">(6)</a> <a href="#ref-for-offset-path-7">(7)</a> <a href="#ref-for-offset-path-8">(8)</a> <a href="#ref-for-offset-path-9">(9)</a> <a href="#ref-for-offset-path-10">(10)</a> <a href="#ref-for-offset-path-11">(11)</a> <a href="#ref-for-offset-path-12">(12)</a> <a href="#ref-for-offset-path-13">(13)</a>
+    <li><a href="#ref-for-offset-path-14">4.2. Position on the path: The offset-distance property</a> <a href="#ref-for-offset-path-15">(2)</a> <a href="#ref-for-offset-path-16">(3)</a> <a href="#ref-for-offset-path-17">(4)</a>
+    <li><a href="#ref-for-offset-path-18">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-offset-path-19">(2)</a> <a href="#ref-for-offset-path-20">(3)</a> <a href="#ref-for-offset-path-21">(4)</a> <a href="#ref-for-offset-path-22">(5)</a> <a href="#ref-for-offset-path-23">(6)</a> <a href="#ref-for-offset-path-24">(7)</a> <a href="#ref-for-offset-path-25">(8)</a> <a href="#ref-for-offset-path-26">(9)</a> <a href="#ref-for-offset-path-27">(10)</a> <a href="#ref-for-offset-path-28">(11)</a>
+    <li><a href="#ref-for-offset-path-29">4.7.1. Calculating the path transform</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="initial-position">
@@ -1650,11 +1648,11 @@ Omitted values are set to their initial values.</p>
   <aside class="dfn-panel" data-for="propdef-offset-distance">
    <b><a href="#propdef-offset-distance">#propdef-offset-distance</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-offset-distance-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-distance-2">(2)</a> <a href="#ref-for-propdef-offset-distance-3">(3)</a> <a href="#ref-for-propdef-offset-distance-4">(4)</a>
-    <li><a href="#ref-for-propdef-offset-distance-5">4.2. Position on the path: The offset-distance property</a>
-    <li><a href="#ref-for-propdef-offset-distance-6">4.2.1. Calculating the computed distance along a path</a>
-    <li><a href="#ref-for-propdef-offset-distance-7">4.5. Rotation at point: The offset-rotate property</a> <a href="#ref-for-propdef-offset-distance-8">(2)</a>
-    <li><a href="#ref-for-propdef-offset-distance-9">4.6. Offset shorthand: The offset property</a>
+    <li><a href="#ref-for-propdef-offset-distance-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-distance-2">(2)</a> <a href="#ref-for-propdef-offset-distance-3">(3)</a> <a href="#ref-for-propdef-offset-distance-4">(4)</a> <a href="#ref-for-propdef-offset-distance-5">(5)</a>
+    <li><a href="#ref-for-propdef-offset-distance-6">4.2. Position on the path: The offset-distance property</a>
+    <li><a href="#ref-for-propdef-offset-distance-7">4.2.1. Calculating the computed distance along a path</a>
+    <li><a href="#ref-for-propdef-offset-distance-8">4.5. Rotation at point: The offset-rotate property</a> <a href="#ref-for-propdef-offset-distance-9">(2)</a>
+    <li><a href="#ref-for-propdef-offset-distance-10">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="used-offset-distance">


### PR DESCRIPTION
The size argument of ray() is no longer optional.

The new keyword 'sides' indicates an angle-specific path length that
extends to the ray's intersection with the containing box.

Discussed in the CSS Working Group:
https://github.com/w3c/fxtf-drafts/issues/73#issuecomment-296084456

Resolves #73