### PR TITLE
[motion] computed distance now supports calc

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -371,20 +371,17 @@ To determine the <dfn>used offset distance</dfn> for a given <a>offset path</a> 
 	sub-paths.
 
 2.  
-    :   If <a>offset distance</a> is a length:
-    ::  Let <var>upper bound</var> be equal to the <a>total length</a>.
-    :   Otherwise:
-    ::  Let <var>upper bound</var> be equal to 100%.
+    Convert <a>offset distance</a> to pixels, with 100% being converted to <dfn>total length</dfn>.
 
 3.  
     :   If <a>offset path</a> is an unbounded ray:
     ::  Let <a>used offset distance</a> be equal to <a>offset distance</a>.
     :   Otherwise if <a>offset path</a> is an <<angle>> path with contain:
-    ::  Let <a>used offset distance</a> be equal to <a>offset distance</a>, clamped by &#8722;<var>upper bound</var> and <var>upper bound</var>.
+    ::  Let <a>used offset distance</a> be equal to <a>offset distance</a>, clamped in magnitude by the total length of the path.
     :   If <a>offset path</a> is any other unclosed interval:
-    ::  Let <a>used offset distance</a> be equal to <a>offset distance</a> clamped by 0 and <var>upper bound</var>.
+    ::  Let <a>used offset distance</a> be equal to <a>offset distance</a> clamped by 0 and the total length of the path.
     :   Otherwise <a>offset path</a> is a closed loop:
-    ::  Let <a>used offset distance</a> be equal to <a>offset distance</a> modulus <var>upper bound</var>.
+    ::  Let <a>used offset distance</a> be equal to <a>offset distance</a> modulus the total length of the path. If the total length of the path is 0, <a>used offset distance</a> is also 0.
 
 </div>
 

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -7,7 +7,7 @@
   <link href="../default.css" rel="stylesheet" type="text/css">
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version 19325e1a3d427dec9961fd38c89c65a206603f18" name="generator">
+  <meta content="Bikeshed version edf04655cdbbf30dd4c7dbad313044553232b75a" name="generator">
   <link href="https://www.w3.org/TR/motion-1/" rel="canonical">
 <style>
   /* Style for bikeshed variant of switch/case <dl>s */
@@ -291,7 +291,7 @@ editors
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-13">13 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-15">15 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -689,17 +689,10 @@ in the path list is a closepath command ("z" or "Z"), otherwise they are unclose
    <div class="switch">
     <ol>
      <li data-md="">
-      <p>Let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="total-length">total length</dfn> be the total length of <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-24">offset path</a> with all
+      <p>Let the <dfn data-dfn-type="dfn" data-noexport="" id="total-length">total length<a class="self-link" href="#total-length"></a></dfn> be the total length of <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-24">offset path</a> with all
 sub-paths.</p>
      <li data-md="">
-      <dl>
-       <dt data-md="">If <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-1">offset distance</a> is a length:
-       <dd data-md="">
-        <p>Let <var>upper bound</var> be equal to the <a data-link-type="dfn" href="#total-length" id="ref-for-total-length-1">total length</a>.</p>
-       <dt data-md="">Otherwise:
-       <dd data-md="">
-        <p>Let <var>upper bound</var> be equal to 100%.</p>
-      </dl>
+      <p>Convert <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-1">offset distance</a> to pixels, with 100% being converted to <dfn data-dfn-type="dfn" data-noexport="" id="total-length0">total length<a class="self-link" href="#total-length0"></a></dfn>.</p>
      <li data-md="">
       <dl>
        <dt data-md="">If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-25">offset path</a> is an unbounded ray:
@@ -707,13 +700,13 @@ sub-paths.</p>
         <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-1">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-2">offset distance</a>.</p>
        <dt data-md="">Otherwise if <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-26">offset path</a> is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> path with contain:
        <dd data-md="">
-        <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-2">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-3">offset distance</a>, clamped by −<var>upper bound</var> and <var>upper bound</var>.</p>
+        <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-2">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-3">offset distance</a>, clamped in magnitude by the total length of the path.</p>
        <dt data-md="">If <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-27">offset path</a> is any other unclosed interval:
        <dd data-md="">
-        <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-3">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-4">offset distance</a> clamped by 0 and <var>upper bound</var>.</p>
+        <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-3">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-4">offset distance</a> clamped by 0 and the total length of the path.</p>
        <dt data-md="">Otherwise <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-28">offset path</a> is a closed loop:
        <dd data-md="">
-        <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-4">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-5">offset distance</a> modulus <var>upper bound</var>.</p>
+        <p>Let <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-4">used offset distance</a> be equal to <a data-link-type="dfn" href="#offset-distance" id="ref-for-offset-distance-5">offset distance</a> modulus the total length of the path. If the total length of the path is 0, <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-5">used offset distance</a> is also 0.</p>
       </dl>
     </ol>
    </div>
@@ -1275,7 +1268,7 @@ Omitted values are set to their initial values.</p>
      <li data-md="">
       <p>Create a supplemental transformation matrix <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="t">T</dfn> for the local coordinate system of the element.</p>
      <li data-md="">
-      <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="p">P</dfn> be the point at the <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-5">used offset distance</a> along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-29">offset path</a>.</p>
+      <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="p">P</dfn> be the point at the <a data-link-type="dfn" href="#used-offset-distance" id="ref-for-used-offset-distance-6">used offset distance</a> along the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-29">offset path</a>.</p>
      <li data-md="">
       <p>Find the translation of the box such that its anchor point is placed at <a data-link-type="dfn" href="#p" id="ref-for-p-1">P</a>, and apply that to <a data-link-type="dfn" href="#t" id="ref-for-t-1">T</a>.</p>
      <li data-md="">
@@ -1397,7 +1390,12 @@ Omitted values are set to their initial values.</p>
    <li><a href="#valdef-offset-rotate-reverse">reverse</a><span>, in §4.5</span>
    <li><a href="#offset-path-sides">sides</a><span>, in §4.1</span>
    <li><a href="#t">T</a><span>, in §4.7.1</span>
-   <li><a href="#total-length">total length</a><span>, in §4.2.1</span>
+   <li>
+    total length
+    <ul>
+     <li><a href="#total-length">definition of</a><span>, in §4.2.1</span>
+     <li><a href="#total-length0">definition of</a><span>, in §4.2.1</span>
+    </ul>
    <li><a href="#used-offset-distance">used offset distance</a><span>, in §4.2.1</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -1658,20 +1656,14 @@ Omitted values are set to their initial values.</p>
   <aside class="dfn-panel" data-for="used-offset-distance">
    <b><a href="#used-offset-distance">#used-offset-distance</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-used-offset-distance-1">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-used-offset-distance-2">(2)</a> <a href="#ref-for-used-offset-distance-3">(3)</a> <a href="#ref-for-used-offset-distance-4">(4)</a>
-    <li><a href="#ref-for-used-offset-distance-5">4.7.1. Calculating the path transform</a>
+    <li><a href="#ref-for-used-offset-distance-1">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-used-offset-distance-2">(2)</a> <a href="#ref-for-used-offset-distance-3">(3)</a> <a href="#ref-for-used-offset-distance-4">(4)</a> <a href="#ref-for-used-offset-distance-5">(5)</a>
+    <li><a href="#ref-for-used-offset-distance-6">4.7.1. Calculating the path transform</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="offset-distance">
    <b><a href="#offset-distance">#offset-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offset-distance-1">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-offset-distance-2">(2)</a> <a href="#ref-for-offset-distance-3">(3)</a> <a href="#ref-for-offset-distance-4">(4)</a> <a href="#ref-for-offset-distance-5">(5)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="total-length">
-   <b><a href="#total-length">#total-length</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-total-length-1">4.2.1. Calculating the computed distance along a path</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-offset-position">


### PR DESCRIPTION
There were previously separate behaviors for lengths vs
percentages of offset-distance in
https://drafts.fxtf.org/motion-1/#calculating-the-computed-distance-along-a-path

This was problematic as calc() can combine the two.

resolves #74