### PR TITLE
[motion] Link to Motion Path's size definition

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -152,14 +152,14 @@ Values have the following meanings:
 </dl>
 
 <dl>
-		<dt><<size>></dt>
+		<dt><dfn type for=''>&lt;size></dfn></dt>
 		<dd>Decides the path length used when 'offset-distance' is expressed as a percentage, using the distance to the containing box. For <<size>> values other than <var>sides</var>, the path length is independent of <<angle>>.
 
 			It is defined as
 
 			&nbsp;<b>&lt;size&gt;</b> = [ closest-side | closest-corner | farthest-side | farthest-corner | sides ]
 
-			<dl>
+			<dl dfn-for="<size>">
 				<dt><dfn>closest-side</dfn></dt>
 				<dd>The distance is measured between the initial position and the closest side
 				of the box from it.</dd>

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -7,7 +7,7 @@
   <link href="../default.css" rel="stylesheet" type="text/css">
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version 19325e1a3d427dec9961fd38c89c65a206603f18" name="generator">
+  <meta content="Bikeshed version edf04655cdbbf30dd4c7dbad313044553232b75a" name="generator">
   <link href="https://www.w3.org/TR/motion-1/" rel="canonical">
 <style>
   /* Style for bikeshed variant of switch/case <dl>s */
@@ -291,7 +291,7 @@ editors
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-13">13 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-15">15 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -423,7 +423,7 @@ editors
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-offset-path">offset-path</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> contain<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> ] ) <br> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="function">&lt;path()></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value">&lt;url></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any">||</a> <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> ]
+      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> <a class="production css" data-link-type="type" href="#typedef-size" id="ref-for-typedef-size-1" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner | sides">&lt;size></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all">&amp;&amp;</a> contain<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt">?</a> ] ) <br> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="function">&lt;path()></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value">&lt;url></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">&lt;basic-shape></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any">||</a> <a class="production css" data-link-type="type" href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">&lt;geometry-box></a> ]
      <tr>
       <th>Initial:
       <td>none
@@ -462,7 +462,7 @@ E.g. A rotation of <span class="css">0 degree</span> points to the upper side of
 and its ancestors have no transformation applied.</p>
    <p>Values have the following meanings:</p>
    <dl>
-    <dt>ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> &amp;&amp; <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a> &amp;&amp; contain? ] )
+    <dt>ray( [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> &amp;&amp; <a class="production css" data-link-type="type" href="#typedef-size" id="ref-for-typedef-size-2" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner | sides">&lt;size></a> &amp;&amp; contain? ] )
     <dd>
      <dl>
       <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>
@@ -484,25 +484,25 @@ and its ancestors have no transformation applied.</p>
 	(as the preceding line doesn’t have "x axis position") </p>
      </dl>
      <dl>
-      <dt><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a>
+      <dt><dfn class="dfn-paneled css" data-dfn-for="" data-dfn-type="type" data-export="" id="typedef-size">&lt;size></dfn>
       <dd>
-       Decides the path length used when <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> is expressed as a percentage, using the distance to the containing box. For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner">&lt;size></a> values other than <var>sides</var>, the path length is independent of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
+       Decides the path length used when <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-3">offset-distance</a> is expressed as a percentage, using the distance to the containing box. For <a class="production css" data-link-type="type" href="#typedef-size" id="ref-for-typedef-size-3" title="Expands to: farthest-side | closest-corner | <length-percentage>{2} | <length> | closest-side | farthest-corner | sides">&lt;size></a> values other than <var>sides</var>, the path length is independent of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
        <p>It is defined as</p>
        <p> <b>&lt;size></b> = [ closest-side | closest-corner | farthest-side | farthest-corner | sides ]</p>
        <dl>
-        <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-closest-side">closest-side<a class="self-link" href="#offset-path-closest-side"></a></dfn>
+        <dt><dfn data-dfn-for="<size>" data-dfn-type="dfn" data-noexport="" id="size-closest-side">closest-side<a class="self-link" href="#size-closest-side"></a></dfn>
         <dd>The distance is measured between the initial position and the closest side
 				of the box from it.
-        <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-closest-corner">closest-corner<a class="self-link" href="#offset-path-closest-corner"></a></dfn>
+        <dt><dfn data-dfn-for="<size>" data-dfn-type="dfn" data-noexport="" id="size-closest-corner">closest-corner<a class="self-link" href="#size-closest-corner"></a></dfn>
         <dd>The distance is measured between the initial position and the closest corner 
 				of the box from it.
-        <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-farthest-side">farthest-side<a class="self-link" href="#offset-path-farthest-side"></a></dfn>
+        <dt><dfn data-dfn-for="<size>" data-dfn-type="dfn" data-noexport="" id="size-farthest-side">farthest-side<a class="self-link" href="#size-farthest-side"></a></dfn>
         <dd>The distance is measured between the initial position and the farthest side 
 				of the box from it.
-        <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-farthest-corner">farthest-corner<a class="self-link" href="#offset-path-farthest-corner"></a></dfn>
+        <dt><dfn data-dfn-for="<size>" data-dfn-type="dfn" data-noexport="" id="size-farthest-corner">farthest-corner<a class="self-link" href="#size-farthest-corner"></a></dfn>
         <dd>The distance is measured between the initial position and the farthest corner
 				of the box from it.
-        <dt><dfn data-dfn-for="offset-path" data-dfn-type="dfn" data-noexport="" id="offset-path-sides">sides<a class="self-link" href="#offset-path-sides"></a></dfn>
+        <dt><dfn data-dfn-for="<size>" data-dfn-type="dfn" data-noexport="" id="size-sides">sides<a class="self-link" href="#size-sides"></a></dfn>
         <dd>The distance is measured between the initial position and the intersection of the ray with the box. If the initial position is not within the box, the distance is 0.
        </dl>
        <p class="note" role="note">Note: When the initial position is on one of the edges of
@@ -1376,11 +1376,11 @@ Omitted values are set to their initial values.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#valdef-offset-rotate-auto">auto</a><span>, in §4.5</span>
-   <li><a href="#offset-path-closest-corner">closest-corner</a><span>, in §4.1</span>
-   <li><a href="#offset-path-closest-side">closest-side</a><span>, in §4.1</span>
+   <li><a href="#size-closest-corner">closest-corner</a><span>, in §4.1</span>
+   <li><a href="#size-closest-side">closest-side</a><span>, in §4.1</span>
    <li><a href="#offset-path-contain">contain</a><span>, in §4.1</span>
-   <li><a href="#offset-path-farthest-corner">farthest-corner</a><span>, in §4.1</span>
-   <li><a href="#offset-path-farthest-side">farthest-side</a><span>, in §4.1</span>
+   <li><a href="#size-farthest-corner">farthest-corner</a><span>, in §4.1</span>
+   <li><a href="#size-farthest-side">farthest-side</a><span>, in §4.1</span>
    <li><a href="#initial-direction">initial direction</a><span>, in §4.1</span>
    <li><a href="#initial-position">initial position</a><span>, in §4.1</span>
    <li><a href="#valdef-offset-path-none">none</a><span>, in §4.1</span>
@@ -1395,7 +1395,8 @@ Omitted values are set to their initial values.</p>
    <li><a href="#p">P</a><span>, in §4.7.1</span>
    <li><a href="#funcdef-offset-path-path">path()</a><span>, in §4.1</span>
    <li><a href="#valdef-offset-rotate-reverse">reverse</a><span>, in §4.5</span>
-   <li><a href="#offset-path-sides">sides</a><span>, in §4.1</span>
+   <li><a href="#size-sides">sides</a><span>, in §4.1</span>
+   <li><a href="#typedef-size">&lt;size></a><span>, in §4.1</span>
    <li><a href="#t">T</a><span>, in §4.7.1</span>
    <li><a href="#total-length">total length</a><span>, in §4.2.1</span>
    <li><a href="#used-offset-distance">used offset distance</a><span>, in §4.2.1</span>
@@ -1422,11 +1423,6 @@ Omitted values are set to their initial values.</p>
     <a data-link-type="biblio">[css-contain-1]</a> defines the following terms:
     <ul>
      <li><a href="https://drafts.csswg.org/css-contain-1/#propdef-contain">contain</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[css-images-3]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.csswg.org/css-images-3/#typedef-size">&lt;size></a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-masking-1]</a> defines the following terms:
@@ -1497,8 +1493,6 @@ Omitted values are set to their initial values.</p>
    <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/">CSS Cascading and Inheritance Level 4</a>. URL: <a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/css-cascade-4/</a>
    <dt id="biblio-css-color-4">[CSS-COLOR-4]
    <dd>Tab Atkins Jr.; Chris Lilley. <a href="https://www.w3.org/TR/css-color-4/">CSS Color Module Level 4</a>. URL: <a href="https://www.w3.org/TR/css-color-4/">https://www.w3.org/TR/css-color-4/</a>
-   <dt id="biblio-css-images-3">[CSS-IMAGES-3]
-   <dd>CSS Image Values and Replaced Content Module Level 3 URL: <a href="https://www.w3.org/TR/css3-images/">https://www.w3.org/TR/css3-images/</a>
    <dt id="biblio-css-masking-1">[CSS-MASKING-1]
    <dd>Dirk Schulze; Brian Birtles; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-masking-1/">CSS Masking Module Level 1</a>. URL: <a href="https://www.w3.org/TR/css-masking-1/">https://www.w3.org/TR/css-masking-1/</a>
    <dt id="biblio-css-shapes">[CSS-SHAPES]
@@ -1643,6 +1637,12 @@ Omitted values are set to their initial values.</p>
    <b><a href="#initial-direction">#initial-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-direction-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-initial-direction-2">(2)</a> <a href="#ref-for-initial-direction-3">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedef-size">
+   <b><a href="#typedef-size">#typedef-size</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedef-size-1">4.1. Define a path: The offset-path property</a> <a href="#ref-for-typedef-size-2">(2)</a> <a href="#ref-for-typedef-size-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-offset-distance">


### PR DESCRIPTION
As an argument of ray paths, <size> supports
'sides', and does not support <length>, or
<length-percentage>{2}.

Thus linking to the CSS Images defintion of
<size> is not appropriate.