### PR TITLE
[geometry] Treat 0 and -0 as equal throughout

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -34,6 +34,7 @@ Default Highlight: javascript
 type: exception; text: SyntaxError; url: https://html.spec.whatwg.org/multipage/infrastructure.html#js-syntaxerror
 urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
     type: dfn
+        text: SameValueZero; url: sec-samevaluezero
         text: ToString; url: sec-tostring
         text: !; url: sec-algorithm-conventions
 </pre>
@@ -459,20 +460,20 @@ a <code>DOMRectInit</code> dictionary</dfn> <var>other</var>, follow these steps
 
  <li><p>Let <var>point1</var> be a new {{DOMPoint}} object with <a for=point>x coordinate</a> set to
  <var>x</var>, <a for=point>y coordinate</a> set to <var>y</var>, <a for=point>z coordinate</a> set
- to zero and <a for=point>w perspective</a> set to one.
+ to ''0'' and <a for=point>w perspective</a> set to ''1''.
 
  <li><p>Let <var>point2</var> be a new {{DOMPoint}} object with <a for=point>x coordinate</a> set to
  <var>x</var> + <var>width</var>, <a for=point>y coordinate</a> set to <var>y</var>, <a for=point>z
- coordinate</a> set to zero and <a for=point>w perspective</a> set to one.
+ coordinate</a> set to ''0'' and <a for=point>w perspective</a> set to ''1''.
 
  <li><p>Let <var>point3</var> be a new {{DOMPoint}} object with <a for=point>x coordinate</a> set to
  <var>x</var> + <var>width</var>, <a for=point>y coordinate</a> set to <var>y</var> +
- <var>height</var>, <a for=point>z coordinate</a> set to zero and <a for=point>w perspective</a> set
- to one.
+ <var>height</var>, <a for=point>z coordinate</a> set to ''0'' and <a for=point>w perspective</a>
+ set to ''1''.
 
  <li><p>Let <var>point4</var> be a new {{DOMPoint}} object with <a for=point>x coordinate</a> set to
  <var>x</var>, <a for=point>y coordinate</a> set to <var>y</var> + <var>height</var>, <a for=point>z
- coordinate</a> set to zero and <a for=point>w perspective</a> set to one.
+ coordinate</a> set to ''0'' and <a for=point>w perspective</a> set to ''1''.
 
  <li><p>Return a new {{DOMQuad}} with <a for=quadrilateral>point 1</a> set to <var>point1</var>, <a
  for=quadrilateral>point 2</a> set to <var>point2</var>, <a for=quadrilateral>point 3</a> set to
@@ -825,29 +826,29 @@ run the following steps:
    {{TypeError}} exception and abort these steps.
 
    <ul>
-    <li><p>{{DOMMatrixInit/a}} and {{DOMMatrixInit/m11}} are both present and their values are not
-    the <a for="WebIDL unrestricted double">same</a>.
+    <li><p>{{DOMMatrixInit/a}} and {{DOMMatrixInit/m11}} are both present and
+    [=SameValueZero=]({{DOMMatrixInit/a}}, {{DOMMatrixInit/m11}}) is <code>false</code>.
 
-    <li><p>{{DOMMatrixInit/b}} and {{DOMMatrixInit/m12}} are both present and their values are not
-    the <a for="WebIDL unrestricted double">same</a>.
+    <li><p>{{DOMMatrixInit/b}} and {{DOMMatrixInit/m12}} are both present and
+    [=SameValueZero=]({{DOMMatrixInit/b}}, {{DOMMatrixInit/m12}}) is <code>false</code>.
 
-    <li><p>{{DOMMatrixInit/c}} and {{DOMMatrixInit/m21}} are both present and their values are not
-    the <a for="WebIDL unrestricted double">same</a>.
+    <li><p>{{DOMMatrixInit/c}} and {{DOMMatrixInit/m21}} are both present and
+    [=SameValueZero=]({{DOMMatrixInit/c}}, {{DOMMatrixInit/m21}}) is <code>false</code>.
 
-    <li><p>{{DOMMatrixInit/d}} and {{DOMMatrixInit/m22}} are both present and their values are not
-    the <a for="WebIDL unrestricted double">same</a>.
+    <li><p>{{DOMMatrixInit/d}} and {{DOMMatrixInit/m22}} are both present and
+    [=SameValueZero=]({{DOMMatrixInit/d}}, {{DOMMatrixInit/m22}}) is <code>false</code>.
 
-    <li><p>{{DOMMatrixInit/e}} and {{DOMMatrixInit/m41}} are both present and their values are not
-    the <a for="WebIDL unrestricted double">same</a>.
+    <li><p>{{DOMMatrixInit/e}} and {{DOMMatrixInit/m41}} are both present and
+    [=SameValueZero=]({{DOMMatrixInit/e}}, {{DOMMatrixInit/m41}}) is <code>false</code>.
 
-    <li><p>{{DOMMatrixInit/f}} and {{DOMMatrixInit/m42}} are both present and their values are not
-    the <a for="WebIDL unrestricted double">same</a>.
+    <li><p>{{DOMMatrixInit/f}} and {{DOMMatrixInit/m42}} are both present and
+    [=SameValueZero=]({{DOMMatrixInit/f}}, {{DOMMatrixInit/m42}}) is <code>false</code>.
 
     <li><p>{{DOMMatrixInit/is2D}} is <code>true</code> and at least one of {{DOMMatrixInit/m13}},
     {{DOMMatrixInit/m14}}, {{DOMMatrixInit/m23}}, {{DOMMatrixInit/m24}}, {{DOMMatrixInit/m31}},
     {{DOMMatrixInit/m32}}, {{DOMMatrixInit/m34}}, {{DOMMatrixInit/m43}} are present with a value
-    other than ''0'', or at least one of {{DOMMatrixInit/m33}}, {{DOMMatrixInit/m44}} are present
-    with a value other than ''1''.
+    other than ''0'' or ''-0'', or at least one of {{DOMMatrixInit/m33}}, {{DOMMatrixInit/m44}} are
+    present with a value other than ''1''.
    </ul>
 
   <li><p>If {{DOMMatrixInit/m11}} is not present then set it to the value of member
@@ -871,18 +872,14 @@ run the following steps:
   <li><p>If {{DOMMatrixInit/is2D}} is not present and at least one of {{DOMMatrixInit/m13}},
   {{DOMMatrixInit/m14}}, {{DOMMatrixInit/m23}}, {{DOMMatrixInit/m24}}, {{DOMMatrixInit/m31}},
   {{DOMMatrixInit/m32}}, {{DOMMatrixInit/m34}}, {{DOMMatrixInit/m43}} are present with a value other
-  than ''0'', or at least one of {{DOMMatrixInit/m33}}, {{DOMMatrixInit/m44}} are present with a
-  value other than ''1'', set {{DOMMatrixInit/is2D}} to <code>false</code>.
+  than ''0'' or ''-0'', or at least one of {{DOMMatrixInit/m33}}, {{DOMMatrixInit/m44}} are present
+  with a value other than ''1'', set {{DOMMatrixInit/is2D}} to <code>false</code>.
 
   <li><p>If {{DOMMatrixInit/is2D}} is still not present, set it to <code>true</code>.
 </ol>
 
-<p>For the purpose of the algorithm above, two WebIDL unrestricted double values are the <dfn
-for="WebIDL unrestricted double">same</dfn> if they have identical IEEE 754 double-precision bit
-patterns.
-
-<p class=note>This means that two ''NaN'' values are the <a for="WebIDL unrestricted
-double">same</a>, but ''0'' and ''-0'' are not the <a for="WebIDL unrestricted double">same</a>.
+<p class=note>The [=SameValueZero=] comparison algorithm returns <code>true</code> for two ''NaN''
+values, and also for ''0'' and ''-0''. [[!ECMA-262]]
 
 
 <h3 id=dommatrix-create>Creating DOMMatrixReadOnly and DOMMatrix objects</h3>
@@ -1093,13 +1090,13 @@ method on {{DOMMatrix}} must follow these steps:
 
  <p>The <dfn><code>m13</code></dfn> attribute, on getting, must return the <a for=matrix>m13
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m13}} attribute must
- set the <a for=matrix>m13 element</a> to the new value and, if the new value is not ''0'', set <a
- for=matrix>is 2D</a> to <code>false</code>.
+ set the <a for=matrix>m13 element</a> to the new value and, if the new value is not ''0'' or
+ ''-0'', set <a for=matrix>is 2D</a> to <code>false</code>.
 
  <p>The <dfn><code>m14</code></dfn> attribute, on getting, must return the <a for=matrix>m14
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m14}} attribute must
- set the <a for=matrix>m14 element</a> to the new value and, if the new value is not ''0'', set <a
- for=matrix>is 2D</a> to <code>false</code>.
+ set the <a for=matrix>m14 element</a> to the new value and, if the new value is not ''0'' or
+ ''-0'', set <a for=matrix>is 2D</a> to <code>false</code>.
 
  <p>The <dfn><code>m21</code></dfn> and <dfn><code>c</code></dfn> attributes, on getting, must
  return the <a for=matrix>m21 element</a> value. For the {{DOMMatrix}} interface, setting the
@@ -1113,23 +1110,23 @@ method on {{DOMMatrix}} must follow these steps:
 
  <p>The <dfn><code>m23</code></dfn> attribute, on getting, must return the <a for=matrix>m23
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m23}} attribute must
- set the <a for=matrix>m23 element</a> to the new value and, if the new value is not ''0'', set <a
- for=matrix>is 2D</a> to <code>false</code>.
+ set the <a for=matrix>m23 element</a> to the new value and, if the new value is not ''0'' or
+ ''-0'', set <a for=matrix>is 2D</a> to <code>false</code>.
 
  <p>The <dfn><code>m24</code></dfn> attribute, on getting, must return the <a for=matrix>m24
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m24}} attribute must
- set the <a for=matrix>m24 element</a> to the new value and, if the new value is not ''0'', set <a
- for=matrix>is 2D</a> to <code>false</code>.
+ set the <a for=matrix>m24 element</a> to the new value and, if the new value is not ''0'' or
+ ''-0'', set <a for=matrix>is 2D</a> to <code>false</code>.
 
  <p>The <dfn><code>m31</code></dfn> attribute, on getting, must return the <a for=matrix>m31
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m31}} attribute must
- set the <a for=matrix>m31 element</a> to the new value and, if the new value is not ''0'', set <a
- for=matrix>is 2D</a> to <code>false</code>.
+ set the <a for=matrix>m31 element</a> to the new value and, if the new value is not ''0'' or
+ ''-0'', set <a for=matrix>is 2D</a> to <code>false</code>.
 
  <p>The <dfn><code>m32</code></dfn> attribute, on getting, must return the <a for=matrix>m32
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m32}} attribute must
- set the <a for=matrix>m32 element</a> to the new value and, if the new value is not ''0'', set <a
- for=matrix>is 2D</a> to <code>false</code>.
+ set the <a for=matrix>m32 element</a> to the new value and, if the new value is not ''0'' or
+ ''-0'', set <a for=matrix>is 2D</a> to <code>false</code>.
 
  <p>The <dfn><code>m33</code></dfn> attribute, on getting, must return the <a for=matrix>m33
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m33}} attribute must
@@ -1138,8 +1135,8 @@ method on {{DOMMatrix}} must follow these steps:
 
  <p>The <dfn><code>m34</code></dfn> attribute, on getting, must return the <a for=matrix>m34
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m34}} attribute must
- set the <a for=matrix>m34 element</a> to the new value and, if the new value is not ''0'', set <a
- for=matrix>is 2D</a> to <code>false</code>.
+ set the <a for=matrix>m34 element</a> to the new value and, if the new value is not ''0'' or
+ ''-0'', set <a for=matrix>is 2D</a> to <code>false</code>.
 
  <p>The <dfn><code>m41</code></dfn> and <dfn><code>e</code></dfn> attributes, on getting, must
  return the <a for=matrix>m41 element</a> value. For the {{DOMMatrix}} interface, setting the
@@ -1153,8 +1150,8 @@ method on {{DOMMatrix}} must follow these steps:
 
  <p>The <dfn><code>m43</code></dfn> attribute, on getting, must return the <a for=matrix>m43
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m43}} attribute must
- set the <a for=matrix>m43 element</a> to the new value and, if the new value is not ''0'', set <a
- for=matrix>is 2D</a> to <code>false</code>.
+ set the <a for=matrix>m43 element</a> to the new value and, if the new value is not ''0'' or
+ ''-0'', set <a for=matrix>is 2D</a> to <code>false</code>.
 
  <p>The <dfn><code>m44</code></dfn> attribute, on getting, must return the <a for=matrix>m44
  element</a> value. For the {{DOMMatrix}} interface, setting the {{DOMMatrix/m44}} attribute must
@@ -1189,8 +1186,8 @@ method on {{DOMMatrix}} must follow these steps:
  for=matrix>m21 element</a>, <a for=matrix>m23 element</a>, <a for=matrix>m24 element</a>, <a
  for=matrix>m31 element</a>, <a for=matrix>m32 element</a>, <a for=matrix>m34 element</a>, <a
  for=matrix>m41 element</a>, <a for=matrix>m42 element</a>, <a for=matrix>m43 element</a> are ''0''
- and <a for=matrix>m11 element</a>, <a for=matrix>m22 element</a>, <a for=matrix>m33 element</a>, <a
- for=matrix>m44 element</a> are ''1''. Otherwise it must return <code>false</code>.
+ or ''-0'' and <a for=matrix>m11 element</a>, <a for=matrix>m22 element</a>, <a for=matrix>m33
+ element</a>, <a for=matrix>m44 element</a> are ''1''. Otherwise it must return <code>false</code>.
 </div>
 
 <p>Every {{DOMMatrixReadOnly}} object must be flagged with a boolean <dfn for=matrix
@@ -1398,8 +1395,8 @@ export>is 2D</dfn>. This flag indicates that:
 
   <p class=note>Even if {{DOMMatrixReadOnly/is2D}} of the current matrix returns <code>true</code>,
   a 4x4 matrix multiplication will be performed if the {{DOMPointReadOnly/z}} attribute of
-  <var>point</var> is not ''0'' or the {{DOMPointReadOnly/w}} attribute of <var>point</var> is not
-  ''1''.
+  <var>point</var> is not ''0'' or ''-0'' or the {{DOMPointReadOnly/w}} attribute of
+  <var>point</var> is not ''1''.
 
  <dt><dfn>toFloat32Array()</dfn>
  <dd><p>Returns the serialized 16 elements {{DOMMatrixReadOnly/m11}} to {{DOMMatrixReadOnly/m44}} of
@@ -1623,8 +1620,8 @@ user agents.
    href="https://drafts.csswg.org/css-transforms-1/#Translate3dDefined">described</a> in CSS
    Transforms. [[!CSS3-TRANSFORMS]]
 
-   <li><p>If <var>tz</var> is specified and not ''0'', set <a for=matrix>is 2D</a> of the current
-   matrix to <code>false</code>.
+   <li><p>If <var>tz</var> is specified and not ''0'' or ''-0'', set <a for=matrix>is 2D</a> of the
+   current matrix to <code>false</code>.
 
    <li><p>Return the current matrix.
   </ol>
@@ -1648,7 +1645,7 @@ user agents.
    <li><p>Perform a {{DOMMatrix/translateSelf()}}</a> transformation on the current matrix with the
    arguments <var>originX</var>, <var>originY</var>, <var>originZ</var>.
 
-   <li><p>If <var>scaleZ</var> is not ''1'' or <var>originZ</var> is not ''0'', set <a
+   <li><p>If <var>scaleZ</var> is not ''1'' or <var>originZ</var> is not ''0'' or ''-0'', set <a
    for=matrix>is 2D</a> of the current matrix to <code>false</code>.
 
    <li><p>Return the current matrix.
@@ -1680,14 +1677,14 @@ user agents.
  <dd>
   <ol>
    <li><p>If <var>rotY</var> and <var>rotZ</var> are both missing, set <var>rotZ</var> to the value
-   of <var>rotX</var> and set <var>rotX</var> and <var>rotY</var> to zero.
+   of <var>rotX</var> and set <var>rotX</var> and <var>rotY</var> to ''0''.
 
-   <li><p>If <var>rotY</var> is still missing, set <var>rotY</var> to zero.
+   <li><p>If <var>rotY</var> is still missing, set <var>rotY</var> to ''0''.
 
-   <li><p>If <var>rotZ</var> is still missing, set <var>rotZ</var> to zero.
+   <li><p>If <var>rotZ</var> is still missing, set <var>rotZ</var> to ''0''.
 
-   <li><p>If <var>rotX</var> or <var>rotY</var> are non-zero, set <a for=matrix>is 2D</a> of the
-   current matrix to <code>false</code>.
+   <li><p>If <var>rotX</var> or <var>rotY</var> are not ''0'' or ''-0'', set <a for=matrix>is 2D</a>
+   of the current matrix to <code>false</code>.
 
    <li><p><a>Post-multiply</a> a rotation transformation on the current matrix around the vector 0,
    0, 1 by the specified rotation <var>rotZ</var> in degrees. The 3D rotation matrix is <a
@@ -1713,9 +1710,9 @@ user agents.
    <li><p><a>Post-multiply</a> a rotation transformation on the current matrix. The rotation angle
    is determined by the angle between the vector (1,0)<sup>T</sup> and
    (<var>x</var>,<var>y</var>)<sup>T</sup> in the clockwise direction. If <var>x</var> and
-   <var>y</var> should both be zero, the angle is specified as zero. The 2D rotation matrix is <a
-   href="https://drafts.csswg.org/css-transforms-1/#RotateDefined">described</a> in CSS Transforms
-   where <code>alpha</code> is the angle between the vector (1,0)<sup>T</sup> and
+   <var>y</var> should both be ''0'' or ''-0'', the angle is specified as ''0''. The 2D rotation
+   matrix is <a href="https://drafts.csswg.org/css-transforms-1/#RotateDefined">described</a> in CSS
+   Transforms where <code>alpha</code> is the angle between the vector (1,0)<sup>T</sup> and
    (<var>x</var>,<var>y</var>)<sup>T</sup> in degrees. [[!CSS3-TRANSFORMS]]
 
    <li><p>Return the current matrix.
@@ -1730,8 +1727,8 @@ user agents.
    href="https://drafts.csswg.org/css-transforms-1/#Rotate3dDefined">described</a> in CSS Transforms
    with <var>alpha</var> = <var>angle</var> in degrees. [[!CSS3-TRANSFORMS]]
 
-   <li><p>If <var>x</var> or <var>y</var> are not ''0'', set <a for=matrix>is 2D</a> of the current
-   matrix to <code>false</code>.
+   <li><p>If <var>x</var> or <var>y</var> are not ''0'' or ''-0'', set <a for=matrix>is 2D</a> of
+   the current matrix to <code>false</code>.
 
    <li><p>Return the current matrix.
   </ol>


### PR DESCRIPTION
This is consistent with other APIs such as JS's Map, Set, and
Array.prototype.includes.

Fixes #152.