### PR TITLE
[motion] Supply size in ray examples

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -202,14 +202,14 @@ Values have the following meanings:
 				background-color: red;
 				width: 50px;
 				height: 50px;
-				offset-path: ray(45deg);
+				offset-path: ray(45deg closest-side);
 				offset-distance: 100%;
 			}
 			#blueBox {
 				background-color: blue;
 				width: 50px;
 				height: 50px;
-				offset-path: ray(180deg);
+				offset-path: ray(180deg closest-side);
 				offset-distance: 100%;
 			}
 		</pre>
@@ -225,14 +225,14 @@ Values have the following meanings:
 				background-color: red;
 				width: 50px;
 				height: 50px;
-				offset-path: ray(45deg contain);
+				offset-path: ray(45deg closest-side contain);
 				offset-distance: 100%;
 			}
 			#blueBox {
 				background-color: blue;
 				width: 50px;
 				height: 50px;
-				offset-path: ray(180deg contain);
+				offset-path: ray(180deg closest-side contain);
 			}
 		</pre>
 		<div class=figure>
@@ -452,27 +452,31 @@ This example shows a way to align elements within the polar coordinate system us
 <pre class="lang-html">
 	&lt;style>
 		body{
+			transform-style: preserve-3d;
 			width: 300px;
 			height: 300px;
 			border: dashed gray;
 			border-radius: 50%;
 		}
 		.circleElement {
+			position: absolute;
+			left: 50%;
+			top: 50%;
 			width: 40px;
 			height: 40px;
 			background-color: red;
 			border-radius: 50%;
 		}
 		#circle1 {
-			offset-path: ray(0deg);
+			offset-path: ray(0deg farthest-side);
 			offset-distance: 50%;
 		}
 		#circle2 {
-			offset-path: ray(90deg);
+			offset-path: ray(90deg farthest-side);
 			offset-distance: 20%;
 		}
 		#circle3 {
-			offset-path: ray(225deg);
+			offset-path: ray(225deg farthest-side);
 			offset-distance: 100%;
 		}
 	&lt;/style>
@@ -595,25 +599,25 @@ This example shows an alignment of four elements with different anchor points.
 			background-color: orange;
 		}
 		#item1 {
-			offset-path: ray(45deg);
+			offset-path: ray(45deg closest-side);
 			offset-distance: 100%;
 			offset-rotate: 0deg;
 			offset-anchor: right top;
 		}
 		#item2 {
-			offset-path: ray(135deg);
+			offset-path: ray(135deg closest-side);
 			offset-distance: 100%;
 			offset-rotate: 0deg;
 			offset-anchor: right bottom;
 			}
 		#item3 {
-			offset-path: ray(225deg);
+			offset-path: ray(225deg closest-side);
 			offset-distance: 100%;
 			offset-rotate: 0deg;
 			offset-anchor: left bottom;
 		}
 		#item4 {
-			offset-path: ray(315deg);
+			offset-path: ray(315deg closest-side);
 			offset-distance: 100%;
 			offset-rotate: 0deg;
 			offset-anchor: left top;
@@ -831,42 +835,44 @@ The computed value of <<angle>> is added to the computed value of ''auto'' or ''
 		body {
 			width: 300px;
 			height: 300px;  
+			margin: 0px;
 			border: solid gray;
 			border-radius: 50%;
 		}
 		.circle {
+			offset-position: 150px 150px;
 			width: 50px;
 			height: 50px;
 			background-color: mediumpurple;
 			border-radius: 50%;
 		}
 		#item1 {
-			offset-path: ray(0deg);
+			offset-path: ray(0deg closest-side);
 			offset-distance: 90%;
 			offset-rotate: auto 90deg;
 		}
 		#item2 {
-			offset-path: ray(45deg);
+			offset-path: ray(45deg closest-side);
 			offset-distance: 90%;
 			offset-rotate: auto 90deg;
 		}
 		#item3 {
-			offset-path: ray(135deg);
+			offset-path: ray(135deg closest-side);
 			offset-distance: 90%;
 			offset-rotate: auto -90deg;
 		}
 		#item4 {
-			offset-path: ray(180deg);
+			offset-path: ray(180deg closest-side);
 			offset-distance: 90%;
 			offset-rotate: auto -90deg;
 		}
 		#item5 {
-			offset-path: ray(225deg);
+			offset-path: ray(225deg closest-side);
 			offset-distance: 90%;
 			offset-rotate: reverse 90deg;
 		}
 		#item6 {
-			offset-path: ray(-45deg);
+			offset-path: ray(-45deg closest-side);
 			offset-distance: 90%;
 			offset-rotate: reverse -90deg;
 		}

--- a/motion-1/Overview.html
+++ b/motion-1/Overview.html
@@ -291,7 +291,7 @@ editors
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Motion Path Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-15">15 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-17">17 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -514,21 +514,21 @@ and its ancestors have no transformation applied.</p>
       <dd> Makes the element don’t have clipped area by altering the length of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-5">offset path</a> when the part of the element on the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-6">offset path</a> is outside the edge of the containing block.
 			If the element is larger than the containing block, the element would be positioned where it has the smallest clipped area by modifying the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-7">offset path</a>’s length with reducing the least amount. 
      </dl>
-     <div class="example" id="example-c1b71b23">
-      <a class="self-link" href="#example-c1b71b23"></a> Here are some examples.
+     <div class="example" id="example-e54ec8fd">
+      <a class="self-link" href="#example-e54ec8fd"></a> Here are some examples.
 		The first example shows that some parts of elements are outside of the <a data-link-type="dfn" href="#offset-path" id="ref-for-offset-path-8">offset path</a>. 
 <pre class="lang-css highlight"><span class="nt">#redBox </span><span class="p">{</span>
   <span class="k">background-color</span><span class="p">:</span> red<span class="p">;</span>
   <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
   <span class="k">height</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
-  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">45</span><span class="l">deg</span><span class="p">)</span><span class="p">;</span>
+  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">45</span><span class="l">deg</span> closest-side<span class="p">)</span><span class="p">;</span>
   <span class="k">offset-distance</span><span class="p">:</span> <span class="m">100</span><span class="l">%</span><span class="p">;</span>
 <span class="p">}</span>
 <span class="nt">#blueBox </span><span class="p">{</span>
   <span class="k">background-color</span><span class="p">:</span> blue<span class="p">;</span>
   <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
   <span class="k">height</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
-  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">180</span><span class="l">deg</span><span class="p">)</span><span class="p">;</span>
+  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">180</span><span class="l">deg</span> closest-side<span class="p">)</span><span class="p">;</span>
   <span class="k">offset-distance</span><span class="p">:</span> <span class="m">100</span><span class="l">%</span><span class="p">;</span>
 <span class="p">}</span>
 </pre>
@@ -542,14 +542,14 @@ and its ancestors have no transformation applied.</p>
   <span class="k">background-color</span><span class="p">:</span> red<span class="p">;</span>
   <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
   <span class="k">height</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
-  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">45</span><span class="l">deg</span> contain<span class="p">)</span><span class="p">;</span>
+  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">45</span><span class="l">deg</span> closest-side contain<span class="p">)</span><span class="p">;</span>
   <span class="k">offset-distance</span><span class="p">:</span> <span class="m">100</span><span class="l">%</span><span class="p">;</span>
 <span class="p">}</span>
 <span class="nt">#blueBox </span><span class="p">{</span>
   <span class="k">background-color</span><span class="p">:</span> blue<span class="p">;</span>
   <span class="k">width</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
   <span class="k">height</span><span class="p">:</span> <span class="m">50</span><span class="l">px</span><span class="p">;</span>
-  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">180</span><span class="l">deg</span> contain<span class="p">)</span><span class="p">;</span>
+  <span class="k">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="m">180</span><span class="l">deg</span> closest-side contain<span class="p">)</span><span class="p">;</span>
 <span class="p">}</span>
 </pre>
       <div class="figure">
@@ -766,31 +766,35 @@ sub-paths.</p>
      <figcaption>An example of elements placed along a closed interval</figcaption>
     </div>
    </div>
-   <div class="example" id="example-ae2df301">
-    <a class="self-link" href="#example-ae2df301"></a> This example shows a way to align elements within the polar coordinate system using <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-6">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-7">offset-distance</a>. 
+   <div class="example" id="example-b9204eaf">
+    <a class="self-link" href="#example-b9204eaf"></a> This example shows a way to align elements within the polar coordinate system using <a class="property" data-link-type="propdesc" href="#propdef-offset-path" id="ref-for-propdef-offset-path-6">offset-path</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance-7">offset-distance</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span><span class="p">{</span>
+    <span class="k">transform-style</span><span class="p">:</span> <span class="kc">preserve-3d</span><span class="p">;</span>
     <span class="k">width</span><span class="p">:</span> <span class="mi">300</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">height</span><span class="p">:</span> <span class="mi">300</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">border</span><span class="p">:</span> <span class="kc">dashed</span> <span class="kc">gray</span><span class="p">;</span>
     <span class="k">border-radius</span><span class="p">:</span> <span class="mi">50</span><span class="kt">%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">.</span><span class="nc">circleElement</span> <span class="p">{</span>
+    <span class="k">position</span><span class="p">:</span> <span class="kc">absolute</span><span class="p">;</span>
+    <span class="k">left</span><span class="p">:</span> <span class="mi">50</span><span class="kt">%</span><span class="p">;</span>
+    <span class="k">top</span><span class="p">:</span> <span class="mi">50</span><span class="kt">%</span><span class="p">;</span>
     <span class="k">width</span><span class="p">:</span> <span class="mi">40</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">height</span><span class="p">:</span> <span class="mi">40</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">background-color</span><span class="p">:</span> <span class="kc">red</span><span class="p">;</span>
     <span class="k">border-radius</span><span class="p">:</span> <span class="mi">50</span><span class="kt">%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">circle1</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">0</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">0</span><span class="kt">deg</span> <span class="n">farthest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">50</span><span class="kt">%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">circle2</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">90</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">90</span><span class="kt">deg</span> <span class="n">farthest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">20</span><span class="kt">%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">circle3</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">225</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">225</span><span class="kt">deg</span> <span class="n">farthest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">100</span><span class="kt">%</span><span class="p">;</span>
   <span class="p">}</span>
 <span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
@@ -920,8 +924,8 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
      <figcaption>A red dot in the middle of a plane shape indicates the shape’s anchor point.</figcaption>
     </div>
    </div>
-   <div class="example" id="example-87f9bcf0">
-    <a class="self-link" href="#example-87f9bcf0"></a> This example shows an alignment of four elements with different anchor points. 
+   <div class="example" id="example-ba5b8861">
+    <a class="self-link" href="#example-ba5b8861"></a> This example shows an alignment of four elements with different anchor points. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span> <span class="p">{</span>
     <span class="k">width</span><span class="p">:</span> <span class="mi">300</span><span class="kt">px</span><span class="p">;</span>
@@ -935,25 +939,25 @@ as the point that is moved along the <a data-link-type="dfn" href="https://url.s
     <span class="k">background-color</span><span class="p">:</span> <span class="kc">orange</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item1</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">45</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">45</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">100</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="mi">0</span><span class="kt">deg</span><span class="p">;</span>
     <span class="n">offset-anchor</span><span class="p">:</span> <span class="kc">right</span> <span class="kc">top</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item2</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">135</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">135</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">100</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="mi">0</span><span class="kt">deg</span><span class="p">;</span>
     <span class="n">offset-anchor</span><span class="p">:</span> <span class="kc">right</span> <span class="kc">bottom</span><span class="p">;</span>
     <span class="p">}</span>
   <span class="p">#</span><span class="nn">item3</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">225</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">225</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">100</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="mi">0</span><span class="kt">deg</span><span class="p">;</span>
     <span class="n">offset-anchor</span><span class="p">:</span> <span class="kc">left</span> <span class="kc">bottom</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item4</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">315</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">315</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">100</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="mi">0</span><span class="kt">deg</span><span class="p">;</span>
     <span class="n">offset-anchor</span><span class="p">:</span> <span class="kc">left</span> <span class="kc">top</span><span class="p">;</span>
@@ -1160,50 +1164,52 @@ on the path.</p>
 	rotated by a fixed amount of degree.</figcaption>
     </div>
    </div>
-   <div class="example" id="example-fc2976e0">
-    <a class="self-link" href="#example-fc2976e0"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-7">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-4">reverse</a> work when specified in combination
+   <div class="example" id="example-a575996a">
+    <a class="self-link" href="#example-a575996a"></a> This example shows how <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-7">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-4">reverse</a> work when specified in combination
 with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a>. 
 The computed value of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" title="Expands to: turn | rad | grad | deg">&lt;angle></a> is added to the computed value of <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-auto" id="ref-for-valdef-offset-rotate-auto-8">auto</a> or <a class="css" data-link-type="maybe" href="#valdef-offset-rotate-reverse" id="ref-for-valdef-offset-rotate-reverse-5">reverse</a>. 
 <pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="nt">body</span> <span class="p">{</span>
     <span class="k">width</span><span class="p">:</span> <span class="mi">300</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">height</span><span class="p">:</span> <span class="mi">300</span><span class="kt">px</span><span class="p">;</span>  
+    <span class="k">margin</span><span class="p">:</span> <span class="mi">0</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">border</span><span class="p">:</span> <span class="kc">solid</span> <span class="kc">gray</span><span class="p">;</span>
     <span class="k">border-radius</span><span class="p">:</span> <span class="mi">50</span><span class="kt">%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">.</span><span class="nc">circle</span> <span class="p">{</span>
+    <span class="n">offset-position</span><span class="p">:</span> <span class="mi">150</span><span class="kt">px</span> <span class="mi">150</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">width</span><span class="p">:</span> <span class="mi">50</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">height</span><span class="p">:</span> <span class="mi">50</span><span class="kt">px</span><span class="p">;</span>
     <span class="k">background-color</span><span class="p">:</span> <span class="kc">mediumpurple</span><span class="p">;</span>
     <span class="k">border-radius</span><span class="p">:</span> <span class="mi">50</span><span class="kt">%</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item1</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">0</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">0</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">90</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="kc">auto</span> <span class="mi">90</span><span class="kt">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item2</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">45</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">45</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">90</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="kc">auto</span> <span class="mi">90</span><span class="kt">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item3</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">135</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">135</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">90</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="kc">auto</span> <span class="mi">-90</span><span class="kt">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item4</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">180</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">180</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">90</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="kc">auto</span> <span class="mi">-90</span><span class="kt">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item5</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">225</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">225</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">90</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="kc">reverse</span> <span class="mi">90</span><span class="kt">deg</span><span class="p">;</span>
   <span class="p">}</span>
   <span class="p">#</span><span class="nn">item6</span> <span class="p">{</span>
-    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">-45</span><span class="kt">deg</span><span class="p">)</span><span class="p">;</span>
+    <span class="n">offset-path</span><span class="p">:</span> <span class="nf">ray</span><span class="p">(</span><span class="mi">-45</span><span class="kt">deg</span> <span class="n">closest</span><span class="o">-</span><span class="n">side</span><span class="p">)</span><span class="p">;</span>
     <span class="n">offset-distance</span><span class="p">:</span> <span class="mi">90</span><span class="kt">%</span><span class="p">;</span>
     <span class="n">offset-rotate</span><span class="p">:</span> <span class="kc">reverse</span> <span class="mi">-90</span><span class="kt">deg</span><span class="p">;</span>
   <span class="p">}</span>


### PR DESCRIPTION
size is now required. The examples now show size explicitly.

The polar placement examples assume the rays begin at the center
of the body. We now make that explicit by setting left/top or by
setting offset-position.