### PR TITLE
[motion] Specify offset-rotate 0deg in examples

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -197,21 +197,33 @@ Values have the following meanings:
 		<div class='example'>
 		Here are some examples.
 		The first example shows that some parts of elements are outside of the <a>offset path</a>.
-		<pre class="lang-css">
-			#redBox {
-				background-color: red;
-				width: 50px;
-				height: 50px;
-				offset-path: ray(45deg closest-side);
-				offset-distance: 100%;
-			}
-			#blueBox {
-				background-color: blue;
-				width: 50px;
-				height: 50px;
-				offset-path: ray(180deg closest-side);
-				offset-distance: 100%;
-			}
+		<pre class="lang-html">
+			&lt;style>
+			  body {
+			    transform-style: preserve-3d;
+			    width: 200px;
+			    height: 200px;
+			  }
+			  .box {
+			    width: 50px;
+			    height: 50px;
+			    offset-position: 50% 50%;
+			    offset-distance: 100%;
+			    offset-rotate: 0deg;
+			  }
+			  #redBox {
+			    background-color: red;
+			    offset-path: ray(45deg closest-side);
+			  }
+			  #blueBox {
+			    background-color: blue;
+			    offset-path: ray(180deg closest-side);
+			  }
+			&lt;/style>
+			&lt;body>
+			  &lt;div class="box" id="redBox">&lt;/div>
+			  &lt;div class="box" id="blueBox">&lt;/div>
+			&lt;/body>
 		</pre>
 		<div class=figure> 
 			<img alt="An image of elements positioned without contain" src="images/offset_distance_without_contain.png" style="width: 200px;"/>
@@ -220,20 +232,33 @@ Values have the following meanings:
 
 		In the second example, 'contain' is given to the 'offset-path' value of each element 
 		to avoid overflowing.
-		<pre class="lang-css">
-			#redBox {
-				background-color: red;
-				width: 50px;
-				height: 50px;
-				offset-path: ray(45deg closest-side contain);
-				offset-distance: 100%;
-			}
-			#blueBox {
-				background-color: blue;
-				width: 50px;
-				height: 50px;
-				offset-path: ray(180deg closest-side contain);
-			}
+		<pre class="lang-html">
+			&lt;style>
+			  body {
+			    transform-style: preserve-3d;
+			    width: 200px;
+			    height: 200px;
+			  }
+			  .box {
+			    width: 50px;
+			    height: 50px;
+			    offset-position: 50% 50%;
+			    offset-distance: 100%;
+			    offset-rotate: 0deg;
+			  }
+			  #redBox {
+			    background-color: red;
+			    offset-path: ray(45deg closest-side contain);
+			  }
+			  #blueBox {
+			    background-color: blue;
+			    offset-path: ray(180deg closest-side contain);
+			  }
+			&lt;/style>
+			&lt;body>
+			  &lt;div class="box" id="redBox">&lt;/div>
+			  &lt;div class="box" id="blueBox">&lt;/div>
+			&lt;/body>
 		</pre>
 		<div class=figure>
 			<img alt="An image of elements positioned with contain" src="images/offset_distance_with_contain.png" style="width: 200px;"/>
@@ -587,47 +612,43 @@ This example shows an alignment of four elements with different anchor points.
 
 <pre class="lang-html">
 	&lt;style>
-		body {
-			width: 300px;
-			height: 300px;
-			border: 2px solid gray;
-			border-radius: 50%;
-		}
-		.box {
-			width: 50px;
-			height: 50px;
-			background-color: orange;
-		}
-		#item1 {
-			offset-path: ray(45deg closest-side);
-			offset-distance: 100%;
-			offset-rotate: 0deg;
-			offset-anchor: right top;
-		}
-		#item2 {
-			offset-path: ray(135deg closest-side);
-			offset-distance: 100%;
-			offset-rotate: 0deg;
-			offset-anchor: right bottom;
-			}
-		#item3 {
-			offset-path: ray(225deg closest-side);
-			offset-distance: 100%;
-			offset-rotate: 0deg;
-			offset-anchor: left bottom;
-		}
-		#item4 {
-			offset-path: ray(315deg closest-side);
-			offset-distance: 100%;
-			offset-rotate: 0deg;
-			offset-anchor: left top;
-		}
+	  body {
+	    transform-style: preserve-3d;
+	    width: 300px;
+	    height: 300px;
+	    border: 2px solid gray;
+	    border-radius: 50%;
+	  }
+	  .box {
+	    width: 50px;
+	    height: 50px;
+	    background-color: orange;
+	    offset-position: 50% 50%;
+	    offset-distance: 100%;
+	    offset-rotate: 0deg;
+	  }
+	  #item1 {
+	    offset-path: ray(45deg closest-side);
+	    offset-anchor: right top;
+	  }
+	  #item2 {
+	    offset-path: ray(135deg closest-side);
+	    offset-anchor: right bottom;
+	  }
+	  #item3 {
+	    offset-path: ray(225deg closest-side);
+	    offset-anchor: left bottom;
+	  }
+	  #item4 {
+	    offset-path: ray(315deg closest-side);
+	    offset-anchor: left top;
+	  }
 	&lt;/style>
 	&lt;body>
-		&lt;div class="box" id="item1">&lt;/div>
-		&lt;div class="box" id="item2">&lt;/div>
-		&lt;div class="box" id="item3">&lt;/div>
-		&lt;div class="box" id="item4">&lt;/div>
+	  &lt;div class="box" id="item1">&lt;/div>
+	  &lt;div class="box" id="item2">&lt;/div>
+	  &lt;div class="box" id="item3">&lt;/div>
+	  &lt;div class="box" id="item4">&lt;/div>
 	&lt;/body>
 </pre>
 <div class=figure>


### PR DESCRIPTION
The default offset-rotate is auto (rotate with the path)
and the default offset-position is auto (path begins at
position from layout or left/top if position: absolute).

The examples that place squares using polar positioning
assume the paths start at the center at that no rotation
occurs.

We now set offset-position: 50% 50% and offset:rotate: 0deg
explicitly.