### PR TITLE
[motion] Create containing blocks

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -77,7 +77,7 @@ A path may consist of an <<angle>> or <<basic-shape>> like <<circle()>>, <<inset
 
 <h2 id="placement">Module interactions</h2>
 
-This specification defines a set of CSS properties that affect the visual rendering of elements to which those properties are applied. These effects are applied after elements have been sized and positioned according to the <a href="https://www.w3.org/TR/CSS2/visuren.html" lt="Visual formatting model">Visual formatting model</a> from [[!CSS21]]. Some values of these properties result in the creation of a <a spec="css21">stacking context</a>.
+This specification defines a set of CSS properties that affect the visual rendering of elements to which those properties are applied. These effects are applied after elements have been sized and positioned according to the <a href="https://www.w3.org/TR/CSS2/visuren.html" lt="Visual formatting model">Visual formatting model</a> from [[!CSS21]]. Some values of these properties result in the creation of a <a spec="css21">stacking context</a> and <a href="https://www.w3.org/TR/CSS2/visuren.html#containing-block">containing block</a>.
 
 Some CSS properties in this specification manipulate the user coordinate system of the element by transformations. These transformations are pre-multiplied to transformations specified by the 'transform' property or deriving properties.
 
@@ -309,9 +309,7 @@ The initial position and the initial direction for basic shapes are defined as f
 	<dd>No <a>offset path</a> gets created. When 'offset-path' is none, 'offset-distance' and 'offset-rotate' have no effect.</dd>
 </dl>
 
-A computed value of other than ''none'' results in the creation of a <a spec="css21">stacking context</a> [[!CSS21]] 
-the same way that CSS 'opacity' [[CSS3COLOR]] does for values other than ''1'',
-unless the element is an SVG element without an associated CSS layout box.
+A computed value of other than ''none'' results in the creation of a <a spec="css21">stacking context</a> [[!CSS21]] and <a href="https://www.w3.org/TR/CSS2/visuren.html#containing-block">containing block</a>, per usual for <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">transforms</a>.
 
 A reference that fails to download, is not a reference to an SVG <a>shape element</a> element,
 or is non-existent, is treated as equivalent to ''path("m 0 0")''.
@@ -520,9 +518,7 @@ with the the containing block as the positioning area
 and a dimensionless point (zero-sized box) as the object area.
 </dl>
 
-A computed value of other than ''auto'' results in the creation of a <a spec="css21">stacking context</a> [[!CSS21]]
-the same way that CSS 'opacity' [[CSS3COLOR]] does for values other than ''1'',
-unless the element is an SVG element without an associated CSS layout box.
+A computed value of other than ''auto'' results in the creation of a <a spec="css21">stacking context</a> [[!CSS21]] and <a href="https://www.w3.org/TR/CSS2/visuren.html#containing-block">containing block</a>, per usual for <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">transforms</a>.
 
 <h3 id="offset-anchor-property">Define an anchor point: The 'offset-anchor' property</h3>
 <pre class='propdef'>


### PR DESCRIPTION
offset-position not none, and/or offset-path not auto,
results in the creation of a stacking context and
containing block, per usual for transforms.

We no longer compare with opacity or exclude SVG.

The wording is now similar to that for the individual
transform properties
https://drafts.csswg.org/css-transforms-2/#individual-transforms

resolves #79