### PR TITLE
[motion] Interaction of offset-position and shapes

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -244,6 +244,10 @@ Values have the following meanings:
 
 <dt><<basic-shape>> || <<geometry-box>></dt>
 <dd>The <a>offset path</a> is a basic shape as specified in CSS Shapes [[!CSS-SHAPES]].
+
+'offset-position' is ignored for circle and ellipse basic shapes with explicit center positions, and for other types of basic shapes. If a circle or ellipse basic shape has no explicit center position, the shape is centered at the initial position of the path, as described in 'offset-position'.
+
+
 The initial position and the initial direction for basic shapes are defined as follows:
 	<dl>
 		<dt><<circle()>></dt>


### PR DESCRIPTION
'offset-position' is ignored for circle and ellipse basic shapes with
explicit center positions, and for other types of basic shapes. If a
circle or ellipse basic shape has no explicit center position, the
shape is centered at the initial position of the path, as described
in 'offset-position'.

resolves #78