### PR TITLE
[motion] Center numbers in circles

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -862,6 +862,9 @@ The computed value of <<angle>> is added to the computed value of ''auto'' or ''
 			height: 50px;
 			background-color: mediumpurple;
 			border-radius: 50%;
+			display: flex;
+			align-items: center;
+			justify-content: center;
 		}
 		#item1 {
 			offset-path: ray(0deg closest-side);


### PR DESCRIPTION
The offset-rotate example image has numbers centered in circles.

We use flexbox to center the numbers, horizontally and vertically.