### PR TITLE
[motion] Example basic shape with implicit center

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -299,14 +299,14 @@ The initial position and the initial direction for basic shapes are defined as f
 
 		<pre class="lang-html">
 			&lt;style>
-				body{
+				body {
 					width: 500px;
 					height: 300px;
 					border-radius: 80px;
 					border: dashed aqua;
 					margin: 0;
 				}
-				#blueBox{
+				#blueBox {
 					width: 40px;
 					height: 20px;
 					background-color: blue;
@@ -320,6 +320,41 @@ The initial position and the initial direction for basic shapes are defined as f
 		<div class="figure">
 			<img alt="An image of example for geometry-box with border-radius" src="images/geometry-box.svg" style="width: 470px; text-align: center"/>
 			<figcaption>The initial position is the left end of the top horizontal line.</figcaption>
+		</div>
+	</div>
+	<div class='example'>
+		This example uses a circle with implicit center position.
+		<pre class="lang-html">
+			&lt;style>
+				body {
+					width: 323px;
+					height: 131px;
+					margin: 0px;
+					border: 2px solid black;
+					padding: 8px;
+					transform-style: preserve-3d;
+				}
+				.item {
+					width:  90px;
+					height: 40px;
+					background-color: violet;
+				}
+				#middle {
+					offset-position: auto;
+					offset-path: circle(60%) margin-box;
+					offset-distance: 25%;
+					offset-anchor: left top;
+				}
+			&lt;/style>
+			&lt;body>
+			  &lt;div class="item">&lt;/div>
+			  &lt;div class="item" id="middle">&lt;/div>
+			  &lt;div class="item">&lt;/div>
+			&lt;/body>
+		</pre>
+		<div class="figure">
+			<img src="images/normal-flow.svg" width="505" height="324" alt="Normal flow determining circle center">
+			<figcaption>The circle center is determined by normal flow.</figcaption>
 		</div>
 	</div>
 	</dd>
@@ -475,7 +510,7 @@ This example shows boxes placed along a closed interval.
 This example shows a way to align boxes within the polar coordinate system using 'offset-path', 'offset-distance'.
 <pre class="lang-html">
 	&lt;style>
-		body{
+		body {
 			transform-style: preserve-3d;
 			width: 300px;
 			height: 300px;

--- a/motion-1/images/normal-flow.svg
+++ b/motion-1/images/normal-flow.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="505" height="324">
+    <style>
+        .border {fill:none;stroke: black;stroke-width: 2;}
+        .crosshairs {stroke: navy;stroke-width: 2;}
+        .item {fill: violet;}
+        .path {fill:none;stroke: cyan;stroke-width: 3;stroke-dasharray: 15,10;}
+    </style>
+    <g transform="translate(162, 162)">
+        <rect class="border" x="-9" y="-49" width="341" height="149" />
+        <rect class="item" x="0" y="-40" width="90" height="40" />
+        <rect class="item" x="119" y="0" width="40" height="90" />
+        <rect class="item" x="0" y="40" width="90" height="40" />
+        <line class="crosshairs" x1="-5" y1="0"
+                                 x2="5" y2="0" />
+        <line class="crosshairs" x1="0" y1="-5"
+                                 x2="0" y2="5" />
+        <circle class="path" cx="0" cy="0" r="159" />
+    </g>
+</svg>


### PR DESCRIPTION
When a circle or ellipse has no explicit center, the center
is determined by offset-position. When offset-position is
auto, position is used.

(In the example, the margin-box has dimensions 343x151 px,
and the circle radius is 60% of 265px.)