### PR TITLE
[motion] Use border-box as default reference box

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -268,7 +268,6 @@ Values have the following meanings:
 
 'offset-position' is ignored for circle and ellipse basic shapes with explicit center positions, and for other types of basic shapes. If a circle or ellipse basic shape has no explicit center position, the shape is centered at the initial position of the path, as described in 'offset-position'.
 
-
 The initial position and the initial direction for basic shapes are defined as follows:
 	<dl>
 		<dt><<circle()>></dt>
@@ -289,6 +288,8 @@ The initial position and the initial direction for basic shapes are defined as f
 		If there is no such unequal coordinate pair, the initial direction is
 		defined as 0 degrees.</dd>
 	</dl>
+
+	The <<geometry-box>> specified in combination with a <<basic-shape>> provides the reference box for the <<basic-shape>>. If no reference box is specified, the border-box will be used as reference box.
 
 	If <<geometry-box>> is supplied without a <<basic-shape>>, the initial position is the left end of the top horizontal line, immediately to the right of any 'border-radius' arc, and the initial direction is to the right.
 
@@ -374,7 +375,7 @@ A computed value of other than ''none'' results in the creation of a <a spec="cs
 A reference that fails to download, is not a reference to an SVG <a>shape element</a>, or is non-existent, is treated as equivalent to ''path("m 0 0")''.
 <p class='note'>Note: This is a zero length path with <a href="https://www.w3.org/TR/SVG11/implnote.html#PathElementImplementationNotes">directionality</a> aligned with the positive x-axis.</p>
 
-See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a>offset path</a>.
+See the section <a href="#calculating-path-transform">“Calculating the path transform”</a> for how to use the <a>offset path</a> to compute the transform.
 
 For SVG <a>shape element</a>s without associated CSS layout box, the <a>used value</a> for <a value for=mask-clip>content-box</a>,
 <a value for=mask-clip>padding-box</a>, <a value for=mask-clip>border-box</a> and <a value for=mask-clip>margin-box</a> is
@@ -427,7 +428,7 @@ To determine the <dfn>used offset distance</dfn> for a given <a>offset path</a> 
 	sub-paths.
 
 2.
-    Convert <a>offset distance</a> to pixels, with 100% being converted to <dfn>total length</dfn>.
+    Convert <a>offset distance</a> to pixels, with 100% being converted to <a>total length</a>.
 
 3.
     :   If <a>offset path</a> is an unbounded ray:


### PR DESCRIPTION
If a basic shape is supplied without a geometry box,
border-box is used by default.

Minor typo corrections so bikeshed runs without error.

Resolves #189