### PR TITLE
Clarify  motion path and position interaction

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -77,7 +77,7 @@ This specification allows authors to specify a path. The object can be positione
 
 This specification defines a set of CSS properties that affect the visual rendering of elements to which those properties are applied. These effects are applied after <a href="https://www.w3.org/TR/css-display-3/#box">box</a>es have been sized and positioned according to the <a href="https://www.w3.org/TR/CSS2/visuren.html" lt="Visual formatting model">Visual formatting model</a> from [[!CSS21]]. Some values of 'offset-path' and 'offset-position' result in the creation of a <a spec="css21">stacking context</a> and <a href="https://www.w3.org/TR/CSS2/visuren.html#containing-block">containing block</a>.
 
-Some CSS properties in this specification manipulate the user coordinate system of the element by transformations. These transformations are pre-multiplied to transformations specified by the 'transform' property or deriving properties defined in CSS Transform Module Level 1 [[!CSS-TRANSFORMS-1]].
+Some CSS properties in this specification manipulate the user coordinate system of the element by transformations. These transformations are pre-multiplied to transformations specified by the 'transform' property or deriving properties defined in CSS Transform Module Level 1 [[!CSS-TRANSFORMS-1]], and post-multiplied to transformations specified by the individual transform properties <a href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">'translate'</a>, <a href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">'scale'</a>, and <a href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">'rotate'</a>, as <a href="https://drafts.csswg.org/css-transforms-2/#ctm">explained</a> in <a href="https://drafts.csswg.org/css-transforms-2/">CSS Transform Module Level 2</a>.
 
 <h2 id="values">Values</h2>
 
@@ -290,7 +290,7 @@ The initial position and the initial direction for basic shapes are defined as f
 		defined as 0 degrees.</dd>
 	</dl>
 
-	If <<geometry-box>> is supplied without a <<basic-shape>>, the initial position is the left end of the top horizontal line, immediately to the right of any 'border-radius' arc, and the initial direction is to the right.
+	If <<geometry-box>> is supplied without a <<basic-shape>>, the initial position is the left end of the top horizontal line, immediately to the right of any 'border-radius' arc, and the initial direction is to the right. 'offset-position' is ignored.
 
 	<div class='example'>
 		This example shows how &lt;geometry-box> <a>offset path</a> works in combination with 'border-radius'.
@@ -374,7 +374,7 @@ A computed value of other than ''none'' results in the creation of a <a spec="cs
 A reference that fails to download, is not a reference to an SVG <a>shape element</a>, or is non-existent, is treated as equivalent to ''path("m 0 0")''.
 <p class='note'>Note: This is a zero length path with <a href="https://www.w3.org/TR/SVG11/implnote.html#PathElementImplementationNotes">directionality</a> aligned with the positive x-axis.</p>
 
-See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a>offset path</a>.
+See the section <a href="#calculating-path-transform">“Calculating the path transform”</a> for how to use the <a>offset path</a> to compute the transform.
 
 For SVG <a>shape element</a>s without associated CSS layout box, the <a>used value</a> for <a value for=mask-clip>content-box</a>,
 <a value for=mask-clip>padding-box</a>, <a value for=mask-clip>border-box</a> and <a value for=mask-clip>margin-box</a> is
@@ -427,7 +427,7 @@ To determine the <dfn>used offset distance</dfn> for a given <a>offset path</a> 
 	sub-paths.
 
 2.
-    Convert <a>offset distance</a> to pixels, with 100% being converted to <dfn>total length</dfn>.
+    Convert <a>offset distance</a> to pixels, with 100% being converted to <a>total length</a>.
 
 3.
     :   If <a>offset path</a> is an unbounded ray:
@@ -563,22 +563,24 @@ Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc"
 
 Specifies the initial position of the <a>offset path</a>.
 
-If 'position' is specified with 'static', 'offset-position' would be ignored.
-
 Values are defined as follows:
 <dl dfn-for="offset-position" dfn-type="value">
 <dt><var>auto</var></dt>
-<dd>Indicates the initial position is the position of the box specified with 'position' property.</dd>
+<dd>Indicates the initial position is the position of the box specified with 'position' property.
+
+<p class='note'>Note: When 'position' is 'static' and 'offset-position' is 'auto' (and not ignored due to 'offset-path'), we have positioning relative to <a href="https://drafts.csswg.org/css-position-3/#normal-flow">normal flow</a>.</p></dd>
 
 <dt><<position>></dt>
-<dd>Specifies the initial position using the <<position>> syntax used by 'background-position',
+<dd>Specifies the initial position,
 with the the containing block as the positioning area
-and a dimensionless point (zero-sized box) as the object area.</dd>
+and a dimensionless point (zero-sized box) as the object area.
+
+<p class='note'>Note: This is similar to absolute positioning, except that 'offset-position' does not prevent boxes from impacting the layout of later siblings.</p></dd>
 </dl>
 
 A computed value of other than ''auto'' results in the creation of a <a spec="css21">stacking context</a> [[!CSS21]] and <a href="https://www.w3.org/TR/CSS2/visuren.html#containing-block">containing block</a>, per usual for <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">transforms</a>.
 
-<p class='issue'>Interaction between the regular CSS positioning ('position', 'top', 'left', 'bottom', 'right') and 'offset-position' needs to be clearer.</p>
+'offset-position' is ignored if 'offset-path' is a geometry-box, or a basic shape (other than a circle or ellipse with implicit center). In these cases, the geometry-box or basic shape specifies the initial position.
 
 <div class='example'>
 This example shows positioning a box with 'offset-position'.
@@ -604,7 +606,7 @@ This example shows positioning a box with 'offset-position'.
     }
   &lt;/style>
   &lt;body>
-    &lt;div id="wrap">&lt;/div>
+    &lt;div id="wrap">
       &lt;div id="box">&lt;/div>
     &lt;/div>
   &lt;/body>
@@ -614,7 +616,164 @@ This example shows positioning a box with 'offset-position'.
   <figcaption>An example when 'auto' is given to 'offset-position'</figcaption>
 </div>
 </div>
-
+<div class='example'>
+This example shows the interaction with the 'transform' property, and with an individual transform property (<a href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">'rotate'</a>). The motion path transform is a vertical translation moving ('left', 'top') to 'offset-position'.
+<pre class="lang-html">
+  &lt;style>
+    #wrap {
+      transform-style: preserve-3d;
+      width: 400px;
+      height: 350px;
+    }
+    .item {
+      position: absolute;
+      left: 200px;
+      top: 0px;
+      offset-position: 200px 100px; /* translates by 0px,100px */
+      offset-anchor: left top;
+      transform-origin: left top;
+      width: 130px;
+      height: 80px;
+      border-top-right-radius: 21px;
+    }
+    #box1 {
+      background-color: tomato;
+      offset-position: auto;
+    }
+    #box2 {
+      background-color: green;
+    }
+    #box3 {
+      background-color: navy;
+      rotate: 90deg; /* applied before motion path transform */
+    }
+    #box4 {
+      background-color: gold;
+      transform: rotate(90deg); /* applied after motion path transform */
+    }
+  &lt;/style>
+  &lt;body>
+    &lt;div id="wrap">
+      &lt;div class="item" id="box1">&lt;/div>
+      &lt;div class="item" id="box2">&lt;/div>
+      &lt;div class="item" id="box3">&lt;/div>
+      &lt;div class="item" id="box4">&lt;/div>
+    &lt;/div>
+  &lt;/body>
+</pre>
+<div class=figure>
+  <img alt="An example when motion path and other transforms interact" src="images/position-transform.svg" width="400" height="350"/>
+  <figcaption>An example when motion path and other transforms interact</figcaption>
+</div>
+</div>
+<div class='example'>
+This example uses 'position' 'static', so 'offset-position' generates translations from the <a href="https://drafts.csswg.org/css-position/#normal-flow">normal flow</a> positions. By amplifying these translations using <a href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">'scale'</a>, the normal flow is rotated 180 degrees around the 'offset-position', and the boxes are exploded away from each other.
+<pre class="lang-html">
+  &lt;style>
+    #wrap {
+      transform-style: preserve-3d;
+      width: 500px;
+      height: 250px;
+      line-height: 0px;
+    }
+    span {
+      position: static;
+      display: inline-block;
+      width: 100px;
+      height: 50px;
+      border-top-right-radius: 21px;
+      scale: 2.5 2.5; /* applied before motion path transform */
+      offset-position: center;
+      transform: scale(0.4); /* applied after motion path transform */
+    }
+    #box1 {
+      background-color: tomato;
+    }
+    #box2 {
+      background-color: green;
+    }
+    #box3 {
+      background-color: navy;
+    }
+    #box4 {
+      background-color: gold;
+    }
+  &lt;/style>
+  &lt;body>
+    &lt;div id="wrap">
+      &lt;div>
+	      &lt;span id="box1">&lt;/span>&lt;span id="box2">&lt;/span>
+      &lt;/div>
+      &lt;div>
+	      &lt;span id="box3">&lt;/span>&lt;span id="box4">&lt;/span>
+      &lt;/div>
+    &lt;/div>
+  &lt;/body>
+</pre>
+<div class=figure>
+  <img alt="An example when motion path and scale interact" src="images/position-scale.svg" width="604" height="304"/>
+  <figcaption>An example when motion path and scale interact</figcaption>
+</div>
+</div>
+<div class='example'>
+In this example, each 'offset-position' value is ignored as 'offset-path' is a <<geometry-box>>, but the other offset properties combine to have an effect equivalent to that for 'offset-position' 'right bottom'.
+<pre class="lang-html">
+  &lt;style>
+    #wrap {
+      transform-style: preserve-3d;
+      width: 540px;
+      height: 420px;
+    }
+    .item {
+      position: absolute;
+      width: 90px;
+      height: 70px;
+      border-top-right-radius: 21px;
+      scale: 0.8 0.8; /* applied before motion path transform */
+      offset-path: padding-box;
+      offset-distance: 50%;
+      offset-rotate: 0deg;
+      offset-anchor: right bottom;
+      transform: scale(1.25); /* applied after motion path transform */
+    }
+    #box1 {
+      background-color: tomato;
+      position: static;
+      offset-position: auto; /* ignored */
+    }
+    #box2 {
+      background-color: green;
+      right: 0px;
+      top: 0px;
+      offset-position: 23% 45%; /* ignored */
+    }
+    #box3 {
+      background-color: navy;
+      left: 0px;
+      bottom: 0px;
+      offset-position: 34% 56px; /* ignored */
+    }
+    #box4 {
+      background-color: gold;
+      right: 0px;
+      bottom: 0px;
+      offset-position: 45px 67px; /* ignored */
+    }
+  &lt;/style>
+  &lt;body>
+    &lt;div id="wrap">
+      &lt;div class="item" id="box1">&lt;/div>
+      &lt;div class="item" id="box2">&lt;/div>
+      &lt;div class="item" id="box3">&lt;/div>
+      &lt;div class="item" id="box4">&lt;/div>
+    &lt;/div>
+  &lt;/body>
+</pre>
+<div class=figure>
+  <img alt="An example when offset-position is ignored" src="images/position-absolute.svg" width="550" height="430"/>
+  <figcaption>An example when offset-position is ignored</figcaption>
+</div>
+</div>
 <h3 id="offset-anchor-property">Define an anchor point: The 'offset-anchor' property</h3>
 <pre class='propdef'>
 Name: offset-anchor

--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -634,7 +634,7 @@ This example shows the interaction with the 'transform' property, and with an in
       transform-origin: left top;
       width: 130px;
       height: 80px;
-      border-top-right-radius: 21px;
+      border-top-right-radius: 23px;
     }
     #box1 {
       background-color: tomato;
@@ -681,7 +681,7 @@ This example uses 'position' 'static', so 'offset-position' generates translatio
       display: inline-block;
       width: 100px;
       height: 50px;
-      border-top-right-radius: 21px;
+      border-top-right-radius: 23px;
       scale: 2.5 2.5; /* applied before motion path transform */
       offset-position: center;
       transform: scale(0.4); /* applied after motion path transform */
@@ -728,7 +728,7 @@ In this example, each 'offset-position' value is ignored as 'offset-path' is a <
       position: absolute;
       width: 90px;
       height: 70px;
-      border-top-right-radius: 21px;
+      border-top-right-radius: 23px;
       scale: 0.8 0.8; /* applied before motion path transform */
       offset-path: padding-box;
       offset-distance: 50%;

--- a/motion-1/images/position-absolute.svg
+++ b/motion-1/images/position-absolute.svg
@@ -12,7 +12,7 @@
         }
     </style>
     <defs>
-        <path id="box" d="M-21,-70 a21,21 0 0 1 21,21 v49 h-90 v-70 z" />
+        <path id="box" d="M-23,-70 a23,23 0 0 1 23,23 v47 h-90 v-70 z" />
     </defs>
     <g transform="translate(542,422)">
         <use xlink:href="#box" fill="tomato" transform="translate(-90,-70)" />

--- a/motion-1/images/position-absolute.svg
+++ b/motion-1/images/position-absolute.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<svg width="550" height="430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+    <style>
+        .crosshairs {
+            stroke: navy;
+            stroke-width: 2;
+        }
+        .boundary {
+            fill: none;
+            stroke-width: 3;
+            stroke-dasharray: 5 5;
+        }
+    </style>
+    <defs>
+        <path id="box" d="M-21,-70 a21,21 0 0 1 21,21 v49 h-90 v-70 z" />
+    </defs>
+    <g transform="translate(542,422)">
+        <use xlink:href="#box" fill="tomato" transform="translate(-90,-70)" />
+        <use xlink:href="#box" fill="green" transform="translate(0,-70)" />
+        <use xlink:href="#box" fill="navy" transform="translate(-90,0)" />
+        <use xlink:href="#box" fill="gold" transform="translate(0,0)" />
+        <use xlink:href="#box" stroke="tomato" transform="translate(-450,-350)" class="boundary" />
+        <use xlink:href="#box" stroke="green" transform="translate(0,-350)" class="boundary" />
+        <use xlink:href="#box" stroke="navy" transform="translate(-450,0)" class="boundary" />
+        <use xlink:href="#box" stroke="gold" transform="translate(0,0)" class="boundary" />
+        <line class="crosshairs" x1="-5" y1="0"
+                                 x2="5" y2="0" />
+        <line class="crosshairs" x1="0" y1="-5"
+                                 x2="0" y2="5" />
+    </g>
+</svg>
+

--- a/motion-1/images/position-scale.svg
+++ b/motion-1/images/position-scale.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<svg width="604" height="304" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+    <style>
+        .crosshairs {
+            stroke: navy;
+            stroke-width: 2;
+        }
+        .boundary {
+            fill: none;
+            stroke-width: 3;
+            stroke-dasharray: 5 5;
+        }
+    </style>
+    <defs>
+        <path id="box" d="M29,-25 a21,21 0 0 1 21,21 v29 h-100 v-50 z" />
+    </defs>
+    <g transform="translate(252,127)">
+        <use xlink:href="#box" fill="tomato" transform="translate(300,150)" />
+        <use xlink:href="#box" fill="green" transform="translate(150,150)" />
+        <use xlink:href="#box" fill="navy" transform="translate(300,75)" />
+        <use xlink:href="#box" fill="gold" transform="translate(150,75)" />
+        <use xlink:href="#box" stroke="tomato" transform="translate(-200,-100)" class="boundary" />
+        <use xlink:href="#box" stroke="green" transform="translate(-100,-100)" class="boundary" stroke-dashoffset="6" />
+        <use xlink:href="#box" stroke="navy" transform="translate(-200,-50)" class="boundary" stroke-dashoffset="6" />
+        <use xlink:href="#box" stroke="gold" transform="translate(-100,-50)" class="boundary" />
+        <line class="crosshairs" x1="-5" y1="0"
+                                 x2="5" y2="0" />
+        <line class="crosshairs" x1="0" y1="-5"
+                                 x2="0" y2="5" />
+    </g>
+</svg>
+

--- a/motion-1/images/position-scale.svg
+++ b/motion-1/images/position-scale.svg
@@ -12,7 +12,7 @@
         }
     </style>
     <defs>
-        <path id="box" d="M29,-25 a21,21 0 0 1 21,21 v29 h-100 v-50 z" />
+        <path id="box" d="M27,-25 a23,23 0 0 1 23,23 v27 h-100 v-50 z" />
     </defs>
     <g transform="translate(252,127)">
         <use xlink:href="#box" fill="tomato" transform="translate(300,150)" />
@@ -20,8 +20,8 @@
         <use xlink:href="#box" fill="navy" transform="translate(300,75)" />
         <use xlink:href="#box" fill="gold" transform="translate(150,75)" />
         <use xlink:href="#box" stroke="tomato" transform="translate(-200,-100)" class="boundary" />
-        <use xlink:href="#box" stroke="green" transform="translate(-100,-100)" class="boundary" stroke-dashoffset="6" />
-        <use xlink:href="#box" stroke="navy" transform="translate(-200,-50)" class="boundary" stroke-dashoffset="6" />
+        <use xlink:href="#box" stroke="green" transform="translate(-100,-100)" class="boundary" stroke-dashoffset="4" />
+        <use xlink:href="#box" stroke="navy" transform="translate(-200,-50)" class="boundary" stroke-dashoffset="4" />
         <use xlink:href="#box" stroke="gold" transform="translate(-100,-50)" class="boundary" />
         <line class="crosshairs" x1="-5" y1="0"
                                  x2="5" y2="0" />

--- a/motion-1/images/position-transform.svg
+++ b/motion-1/images/position-transform.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<svg width="400" height="350" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+    <style>
+        path {
+            transform-origin: 0 0;
+        }
+        .crosshairs {
+            stroke: navy;
+            stroke-width: 2;
+        }
+        .boundary {
+            fill: none;
+            stroke-width: 3;
+            stroke-dasharray: 5 15;
+        }
+    </style>
+    <defs>
+        <path id="box" d="M109,0 a21,21 0 0 1 21,21 v59 h-130 v-80 z" />
+    </defs>
+    <g transform="translate(200,0)">
+        <use xlink:href="#box" fill="tomato" />
+        <use xlink:href="#box" fill="green" transform="translate(0,100)" />
+        <use xlink:href="#box" fill="navy" transform="rotate(90) translate(0,100)" />
+        <use xlink:href="#box" fill="gold" transform="translate(0,100) rotate(90)" />
+
+        <use xlink:href="#box" stroke="tomato" class="boundary" />
+        <use xlink:href="#box" stroke="green" class="boundary" stroke-dashoffset="5" />
+        <use xlink:href="#box" stroke="navy" class="boundary" stroke-dashoffset="10" />
+        <use xlink:href="#box" stroke="gold" class="boundary" stroke-dashoffset="15" />
+    </g>
+    <g transform="translate(200, 100)">
+        <line class="crosshairs" x1="-5" y1="0"
+                                 x2="5" y2="0" />
+        <line class="crosshairs" x1="0" y1="-5"
+                                 x2="0" y2="5" />
+    </g>
+</svg>
+

--- a/motion-1/images/position-transform.svg
+++ b/motion-1/images/position-transform.svg
@@ -15,7 +15,7 @@
         }
     </style>
     <defs>
-        <path id="box" d="M109,0 a21,21 0 0 1 21,21 v59 h-130 v-80 z" />
+        <path id="box" d="M107,0 a23,23 0 0 1 23,23 v57 h-130 v-80 z" />
     </defs>
     <g transform="translate(200,0)">
         <use xlink:href="#box" fill="tomato" />


### PR DESCRIPTION
If offset-position is a position, the motion path translation (and
hence left/right/top/bottom if position is 'absolute') can be observed
if 'rotate' or 'scale' are set.
https://drafts.csswg.org/css-transforms-2/#ctm

If offset-path is a geometry-box, or a basic shape (other than a circle
or ellipse with implicit center), then the value of offset-position is
ignored and we have absolute positioning even if offset-position is
'auto' and position is 'static'.
https://drafts.fxtf.org/motion-1/#offset-path-property

offset-position and offset-anchor do not support the deprecated 3-value
syntax used by 'background-position'
https://lists.w3.org/Archives/Public/www-style/2017Mar/0054.html

position 'static' (the initial value) does not cause offset-position to
be ignored, just as it does not cause offset-path to be ignored.

resolves #45
resolves #77