### PR TITLE
Simplify description of initial direction

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -107,8 +107,6 @@ Specifies the <a>offset path</a>, a geometrical path the box gets positioned on.
 An <dfn>offset path</dfn> is either a specified path with one or multiple sub-paths or the geometry
 of a not styled basic shape.
 
-A path must define an <dfn>initial position</dfn> and an <dfn>initial direction</dfn> of the box on the path. The <a>initial position</a> describes the position of the box along the path when '0%' is given for 'offset-distance'. Also the <a>initial direction</a> is the rotation of the box on the <a>initial position</a> before specifying 'offset-rotate'.
-
 A path may consist of a <a>ray</a> or a <<basic-shape>> like <<circle()>>, <<inset()>> or <<polygon()>>. To allow authors to specify curves and sub-paths, this specification adds the <<path()>> function in addition to the existing <<basic-shape>> functions. The <<path()>> function takes an SVG Path string as input [[!SVG2]]. As another option, authors may reference an SVG <a>shape element</a> by <<url>> which is used as the path.
 
 In this specification, a direction (or rotation) of ''0 degree'' is equivalent to the direction of
@@ -129,7 +127,7 @@ Values have the following meanings:
 	The <a>offset path</a> is a line segment that starts from the position of the box and proceeds in the
 	direction defined by the specified <<angle>>. As with
 	<a href="https://www.w3.org/TR/css3-images/#gradients">CSS gradients</a>, <<angle>> values are interpreted
-	as bearing angles, with '0deg' pointing up and positive angles representing clockwise rotation.
+	as bearing angles, with ''0deg'' pointing up and positive angles representing clockwise rotation.
 
 	<p class="note">Note: Defining an <a>offset path</a> with <<angle>>,
 	the box can be positioned with the used of polar coordinates.
@@ -268,29 +266,28 @@ Values have the following meanings:
 
 'offset-position' is ignored for circle and ellipse basic shapes with explicit center positions, and for other types of basic shapes. If a circle or ellipse basic shape has no explicit center position, the shape is centered at the initial position of the path, as described in 'offset-position'.
 
+The <dfn>initial position</dfn> and <dfn>initial direction</dfn> of the path describe the position of the box along the path when 'offset-distance' begins increasing from ''0%''.
 
-The initial position and the initial direction for basic shapes are defined as follows:
+The <a>initial position</a> for basic shapes are defined as follows:
 	<dl>
 		<dt><<circle()>></dt>
 		<dt><<ellipse()>></dt>
-		<dd>The <a>initial position</a> is defined by the point where a virtual tangent
-		to the circle/ellipse would reach the top vertical position.
-		The <a>initial direction</a> is 90 degrees.</dd>
+		<dd>The <a>initial position</a> is defined by the point where a horizontal tangent
+		to the circle/ellipse would reach the top vertical position.</dd>
 		<dt><<inset()>></dt>
-		<dd>The <a>initial position</a> is defined by the left top corner
-		of the rectangle.
-		The <a>initial direction</a> is 0 degree.</dd>
+		<dd>The <a>initial position</a> is the left end of the top horizontal line, immediately to the right of any 'border-radius' arc.</dd>
 		<dt><<polygon()>></dt>
 		<dd>The <a>initial position</a> is defined by the first coordinate pair
 		of the polygon.
 		The <a>initial direction</a> is defined by the vector connecting
 		the initial position with the next following coordinate pair
-		that isn't equal to the initial position.
-		If there is no such unequal coordinate pair, the initial direction is
-		defined as 0 degrees.</dd>
+		that isn't equal to the initial position.</dd>
 	</dl>
 
-	If <<geometry-box>> is supplied without a <<basic-shape>>, the initial position is the left end of the top horizontal line, immediately to the right of any 'border-radius' arc, and the initial direction is to the right.
+	If <<geometry-box>> is supplied without a <<basic-shape>>, the <a>initial position</a> is the left end of the top horizontal line, immediately to the right of any 'border-radius' arc.
+
+Apart from polygons with non-zero length, the <a>initial direction</a> is 90 degrees (i.e. to the right).
+<p class="note">Note: This gives ''0deg'' rotation when 'offset-rotate' is ''auto''.</p>
 
 	<div class='example'>
 		This example shows how &lt;geometry-box> <a>offset path</a> works in combination with 'border-radius'.
@@ -366,7 +363,7 @@ The initial position and the initial direction for basic shapes are defined as f
 	See SVG 1.1 for more information about the initial position and initial direction [[!SVG11]].
 	</dd>
 	<dt dfn-type=value><dfn>none</dfn></dt>
-	<dd>No <a>offset path</a> gets created. When 'offset-path' is none, 'offset-distance' and 'offset-rotate' have no effect.</dd>
+	<dd>No <a>offset path</a> gets created. When 'offset-path' is ''none'', 'offset-distance' and 'offset-rotate' have no effect.</dd>
 </dl>
 
 A computed value of other than ''none'' results in the creation of a <a spec="css21">stacking context</a> [[!CSS21]] and <a href="https://www.w3.org/TR/CSS2/visuren.html#containing-block">containing block</a>, per usual for <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">transforms</a>.
@@ -374,7 +371,7 @@ A computed value of other than ''none'' results in the creation of a <a spec="cs
 A reference that fails to download, is not a reference to an SVG <a>shape element</a>, or is non-existent, is treated as equivalent to ''path("m 0 0")''.
 <p class='note'>Note: This is a zero length path with <a href="https://www.w3.org/TR/SVG11/implnote.html#PathElementImplementationNotes">directionality</a> aligned with the positive x-axis.</p>
 
-See the section <a href="#offset-processing">“Offset processing”</a> for how to process an <a>offset path</a>.
+See the section <a href="#calculating-path-transform">“Calculating the path transform”</a> for how to use the <a>offset path</a> to compute the transform.
 
 For SVG <a>shape element</a>s without associated CSS layout box, the <a>used value</a> for <a value for=mask-clip>content-box</a>,
 <a value for=mask-clip>padding-box</a>, <a value for=mask-clip>border-box</a> and <a value for=mask-clip>margin-box</a> is
@@ -427,7 +424,7 @@ To determine the <dfn>used offset distance</dfn> for a given <a>offset path</a> 
 	sub-paths.
 
 2.
-    Convert <a>offset distance</a> to pixels, with 100% being converted to <dfn>total length</dfn>.
+    Convert <a>offset distance</a> to pixels, with 100% being converted to <a>total length</a>.
 
 3.
     :   If <a>offset path</a> is an unbounded ray:
@@ -563,7 +560,7 @@ Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc"
 
 Specifies the initial position of the <a>offset path</a>.
 
-If 'position' is specified with 'static', 'offset-position' would be ignored.
+If 'position' is specified with ''static'', 'offset-position' would be ignored.
 
 Values are defined as follows:
 <dl dfn-for="offset-position" dfn-type="value">
@@ -611,7 +608,7 @@ This example shows positioning a box with 'offset-position'.
 </pre>
 <div class=figure>
   <img alt="An image of offset-position: auto" src="images/offset_position_auto.png" width="300"/>
-  <figcaption>An example when 'auto' is given to 'offset-position'</figcaption>
+  <figcaption>An example when ''auto'' is given to 'offset-position'</figcaption>
 </div>
 </div>
 
@@ -842,7 +839,7 @@ the angle of the direction
 If specified in combination with <<angle>>, the computed value of <<angle>> is added
 to the computed value of ''auto''.</dd>
 
-<p class='note'>Note: For ray paths, the rotation implied by 'auto' is 90 degrees less than the ray's bearing <<angle>>.</p>
+<p class='note'>Note: For ray paths, the rotation implied by ''auto'' is 90 degrees less than the ray's bearing <<angle>>.</p>
 
 <dt><dfn>reverse</dfn></dt>
 <dd>Indicates that the object is rotated (over time if 'offset-distance' is animated) by
@@ -877,7 +874,7 @@ When no offset properties are set, the shape is not translated or rotated along 
 </div>
 
 When the shape's <a>anchor point</a> is placed at different positions along the path and
-'offset-rotate' is '0deg', the shape is not rotated.
+'offset-rotate' is ''0deg'', the shape is not rotated.
 <div class=figure>
 	<img src="images/offset-rotate-none.svg" width="470" height="120" alt="Path without rotation">
 	<figcaption>A black plane at different positions on a blue dotted path without


### PR DESCRIPTION
The initial direction describes how the position changes when
offset-distance is increasing from 0%.

The offset-rotate 'auto' rotation can be deduced from this.

inset() can have a border radius, we need to take that into
account in the initial position.

The initial direction was also discussed in #76