### PR TITLE
[motion-1] Clarify meaning of contain

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -182,9 +182,9 @@ Values have the following meanings:
 <dl>
 		<dt><dfn>contain</dfn></dt>
 		<dd>
-			Makes the box don't have clipped area by altering the length of the <a>offset path</a> when the part of the box on the <a>offset path</a> is outside the edge of the containing block.
-			If the box is larger than the containing block, the box would be positioned where it has the smallest clipped area by modifying the <a>offset path</a>’s length with reducing the least amount.
+			The used value of 'offset-distance' is clamped so that the box is entirely contained within the path.
 
+			If no 'offset-distance' would lead to the box being enclosed by the path, the path size is minimally increased so that such an 'offset-distance' exists.
 		</dd>
 </dl>
 
@@ -257,6 +257,35 @@ Values have the following meanings:
 		<div class=figure>
 			<img alt="An image of boxes positioned with contain" src="images/offset_distance_with_contain.png" style="width: 200px;"/>
 			<figcaption>'offset-path' with 'contain'</figcaption>
+		</div>
+		In the third example, the path size is increased so that the box can be contained. The <a>used offset distance</a> is negative.
+		<pre class="lang-html">
+			&lt;style>
+			  body {
+			    transform-style: preserve-3d;
+			    width: 250px;
+			    height: 250px;
+			  }
+			  .box {
+					width: 60%;
+					height: 10%;
+
+					offset-position: 20% 20%;
+					offset-distance: 0%;
+					offset-anchor: 200% -300%;
+			  }
+			  #blueBox {
+			    background-color: blue;
+			    offset-path: ray(-90deg closest-side contain);
+			  }
+			&lt;/style>
+			&lt;body>
+			  &lt;div class="box" id="blueBox">&lt;/div>
+			&lt;/body>
+		</pre>
+		<div class=figure>
+			<img alt="An image of an increased path size" src="images/increase-size.svg" style="width: 400px; height: 335;"/>
+			<figcaption>'offset-path' with path size increased</figcaption>
 		</div>
 		</div>
 </dd>
@@ -431,7 +460,7 @@ To determine the <dfn>used offset distance</dfn> for a given <a>offset path</a> 
     :   If <a>offset path</a> is an unbounded ray:
     ::  Let <a>used offset distance</a> be equal to <a>offset distance</a>.
     :   Otherwise if <a>offset path</a> is an <<angle>> path with contain:
-    ::  Let <a>used offset distance</a> be equal to <a>offset distance</a>, clamped in magnitude by the total length of the path.
+    ::  Let <a>used offset distance</a> be equal to <a>offset distance</a>, clamped so that the box lies entirely within the path.
     :   If <a>offset path</a> is any other unclosed interval:
     ::  Let <a>used offset distance</a> be equal to <a>offset distance</a> clamped by 0 and the total length of the path.
     :   Otherwise <a>offset path</a> is a closed loop:

--- a/motion-1/images/increase-size.svg
+++ b/motion-1/images/increase-size.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="400" height="335">
+    <style>
+        .boundary {
+            fill-opacity: 0;
+            stroke: #ccc;
+            stroke-width: 2;
+            stroke-dasharray: 5,3;
+        }
+        .ray {
+            stroke: cyan;
+            stroke-width: 3;
+            stroke-dasharray: 15,10;
+        }
+    </style>
+    <rect class="boundary" x="100" y="80" width="250" height="250" />
+    <circle class="boundary" cx="150" cy="130" r="50" />
+    <circle class="boundary" cx="150" cy="130" r="125" />
+    <g transform="translate(150, 130)">
+        <polygon class="placed" fill="blue"
+                 points="-300,75
+                         -150,75
+                         -150,100
+                         -300,100"
+                 transform="translate(225, 0)"/>
+        <line class="ray" x1="0" y1="0"
+                          x2="225" y2="0" />
+    </g>
+</svg>


### PR DESCRIPTION
'smallest clipped area' gave no guidance when the path and the box
had zero area in common regarless of the value of offset-distance.

For example, this can occur when the path size is 0, or when
offset-anchor is substantially outside the box.

We now define the meaning of 'contain' by specifying that the path
size is minimally increased so that the box can be contained.

resolves #22