### PR TITLE
[geometry] Replace serializers with "[Default] toJSON()".

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -82,7 +82,7 @@ interface DOMPointReadOnly {
 
     DOMPoint matrixTransform(optional DOMMatrixInit matrix);
 
-    serializer = { attribute };
+    [Default] object toJSON();
 };
 
 [Constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
@@ -300,7 +300,7 @@ interface DOMRectReadOnly {
     readonly attribute unrestricted double bottom;
     readonly attribute unrestricted double left;
 
-    serializer = { attribute };
+    [Default] object toJSON();
 };
 
 [Constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
@@ -452,7 +452,7 @@ interface DOMQuad {
     [SameObject] readonly attribute DOMPoint p4;
     [NewObject] DOMRect getBounds();
 
-    serializer = { attribute };
+    [Default] object toJSON();
 };
 
 dictionary DOMQuadInit {
@@ -748,7 +748,7 @@ interface DOMMatrixReadOnly {
     [NewObject] Float64Array toFloat64Array();
 
     [Exposed=Window] stringifier;
-    serializer = { attribute };
+    [Default] object toJSON();
 };
 
 [Constructor(optional (DOMString or sequence&lt;unrestricted double>) init),


### PR DESCRIPTION
Match latest WebIDL spec[1]. This fixes #200.

[1] https://heycam.github.io/webidl/#Default