### PR TITLE
[filter-effects] hue-rotate() takes unitless zero

### DIFF
--- a/filter-effects/Overview.bs
+++ b/filter-effects/Overview.bs
@@ -319,9 +319,11 @@ Issue(1): Make parameters optional?
         Negative values are not allowed.
 
         The <a for=svg>initial value</a> for interpolation is ''0''.
-    : <dfn>hue-rotate()</dfn> = hue-rotate( <<angle>> )
+    : <dfn>hue-rotate()</dfn> = hue-rotate( [ <<angle>> | <<zero>> ] )
     ::
         Applies a hue rotation on the input image. The passed parameter defines the number of degrees around the color circle the input samples will be adjusted. A value of ''0deg'' leaves the input unchanged. Implementations must not normalize this value in order to allow animations beyond ''360deg''. The markup equivalent of this function is <a href="#huerotateEquivalent">given below</a>.
+
+        The unit identifier may be omitted if the <<angle>> is zero.
 
         The <a for=svg>initial value</a> for interpolation is ''0deg''.
     : <dfn>invert()</dfn> = invert( <<number-percentage>> )


### PR DESCRIPTION
Like gradients and transform, hue-rotate() accepts
unitless 0.

Test:
https://github.com/w3c/web-platform-tests/pull/7890

resolves #228