### PR TITLE
[Geometry-1] TYPO: transposed DOMPointReadOnly and DOMPoint...

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -110,7 +110,7 @@ dictionary DOMPointInit {
 variables <dfn dfn-for=point id=point-x-coordinate>x coordinate</dfn>, <dfn dfn-for=point
 id=point-y-coordinate>y coordinate</dfn>, <dfn dfn-for=point id=point-z-coordinate>z
 coordinate</dfn> and <dfn dfn-for=point id=point-w-perspective>w perspective</dfn>.
-{{DOMPointReadOnly}} as well as the inheriting interface {{DOMPoint}} must be able to access and set
+{{DOMPoint}} as well as the inheriting interface {{DOMPointReadOnly}} must be able to access and set
 the value of these variables.
 
 <p>An interface returning an {{DOMPointReadOnly}} object by an attribute or function may be able to


### PR DESCRIPTION
Typo: transposed DOMPointReadOnly and DOMPoint so the text matches the IDL. I think that's what was intended. (As with so much of this spec, the intent is opaque.)