### PR TITLE
Correct inclusion of SVGURIReference

### DIFF
--- a/filter-effects/appendix/interfaces.md
+++ b/filter-effects/appendix/interfaces.md
@@ -12,7 +12,7 @@ interface SVGFilterElement : SVGElement {
   readonly attribute SVGAnimatedLength height;
 };
 
-SVGFilterElement implements SVGURIReference;
+SVGFilterElement includes SVGURIReference;
 </pre>
 
 <div dfn-type=attribute dfn-for=SVGFilterElement>
@@ -744,7 +744,7 @@ interface SVGFEImageElement : SVGElement {
 };
 
 SVGFEImageElement includes SVGFilterPrimitiveStandardAttributes;
-SVGFEImageElement implements SVGURIReference;
+SVGFEImageElement includes SVGURIReference;
 </pre>
 
 <div dfn-type=attribute dfn-for=SVGFEImageElement>


### PR DESCRIPTION
SVGURIReference is an `interface mixin`, not an `interface`, so the operator is `includes` not `implements`.

Found this when cleaning up the SVG deps for https://github.com/web-platform-tests/wpt/issues/11796