### PR TITLE
[compositing] Use prod class for production rules

### DIFF
--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -117,7 +117,7 @@ Animatable: no
 
 The syntax of the property of <<blend-mode>> is given with:
 
-<pre class="blendmode"><dfn id="ltblendmodegt">&lt;blend-mode></dfn> = <a value>normal</a> | <a value>multiply</a> | <a value>screen</a> | <a value>overlay</a> | <a value>darken</a> | <a value>lighten</a> | <a value>color-dodge</a> |
+<pre class="blendmode prod"><dfn id="ltblendmodegt">&lt;blend-mode></dfn> = <a value>normal</a> | <a value>multiply</a> | <a value>screen</a> | <a value>overlay</a> | <a value>darken</a> | <a value>lighten</a> | <a value>color-dodge</a> |
   <a value>color-burn</a> | <a value>hard-light</a> | <a value>soft-light</a> | <a value>difference</a> | <a value>exclusion</a> | <a value>hue</a> |
   <a value>saturation</a> | <a value>color</a> | <a value>luminosity</a></pre>
 
@@ -260,7 +260,7 @@ Animatable: no
 
 The syntax of the property of <<isolation-mode>> is given with:
 
-<pre class="isolated"><dfn id="isolated-propid">&lt;isolation-mode></dfn> = auto | isolate</pre>
+<pre class="isolated prod"><dfn id="isolated-propid">&lt;isolation-mode></dfn> = auto | isolate</pre>
 
 <p id="img_isolation">
 In CSS, a background image or the content of an <a element>img</a> must always be rendered into an isolated group.<br>For instance, if you link to an SVG file through the <a element>img</a> tag, the artwork of that SVG will not blend with the backdrop of the content.</p>
@@ -350,7 +350,7 @@ This property takes the following value:
 
 The syntax of the property of <<composite-mode>> is given with:
 
-<pre class="compositemode"><dfn id="compositemode">&lt;composite-mode></dfn> = <a href="#porterduffcompositingoperators_clear">clear</a> | <a href="#porterduffcompositingoperators_src">copy</a> | <a href="#porterduffcompositingoperators_srcover">source-over</a> | <a href="#porterduffcompositingoperators_dstover">destination-over</a> | <a href="#porterduffcompositingoperators_srcin">source-in</a> | <br><a href="#porterduffcompositingoperators_dstin">destination-in</a> | <a href="#porterduffcompositingoperators_srcout">source-out</a> | <a href="#porterduffcompositingoperators_dstout">destination-out</a> | <a href="#porterduffcompositingoperators_srcatop">source-atop</a> | <br><a href="#porterduffcompositingoperators_dstatop">destination-atop</a> | <a href="#porterduffcompositingoperators_xor">xor</a> | <a href="#porterduffcompositingoperators_plus">lighter</a></pre>
+<pre class="compositemode prod"><dfn id="compositemode">&lt;composite-mode></dfn> = <a href="#porterduffcompositingoperators_clear">clear</a> | <a href="#porterduffcompositingoperators_src">copy</a> | <a href="#porterduffcompositingoperators_srcover">source-over</a> | <a href="#porterduffcompositingoperators_dstover">destination-over</a> | <a href="#porterduffcompositingoperators_srcin">source-in</a> | <br><a href="#porterduffcompositingoperators_dstin">destination-in</a> | <a href="#porterduffcompositingoperators_srcout">source-out</a> | <a href="#porterduffcompositingoperators_dstout">destination-out</a> | <a href="#porterduffcompositingoperators_srcatop">source-atop</a> | <br><a href="#porterduffcompositingoperators_dstatop">destination-atop</a> | <a href="#porterduffcompositingoperators_xor">xor</a> | <a href="#porterduffcompositingoperators_plus">lighter</a></pre>
 
 <h2 id="whatiscompositing">Introduction to compositing</h2>
 

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -117,7 +117,7 @@ Animatable: no
 
 The syntax of the property of <<blend-mode>> is given with:
 
-<pre class="blendmode"><dfn id="ltblendmodegt">&lt;blend-mode></dfn> = <a value>normal</a> | <a value>multiply</a> | <a value>screen</a> | <a value>overlay</a> | <a value>darken</a> | <a value>lighten</a> | <a value>color-dodge</a> |
+<pre class="blendmode prod"><dfn id="ltblendmodegt">&lt;blend-mode></dfn> = <a value>normal</a> | <a value>multiply</a> | <a value>screen</a> | <a value>overlay</a> | <a value>darken</a> | <a value>lighten</a> | <a value>color-dodge</a> |
   <a value>color-burn</a> | <a value>hard-light</a> | <a value>soft-light</a> | <a value>difference</a> | <a value>exclusion</a> | <a value>hue</a> |
   <a value>saturation</a> | <a value>color</a> | <a value>luminosity</a></pre>
 
@@ -260,7 +260,7 @@ Animatable: no
 
 The syntax of the property of <<isolation-mode>> is given with:
 
-<pre class="isolated"><dfn id="isolated-propid">&lt;isolation-mode></dfn> = auto | isolate</pre>
+<pre class="isolated prod"><dfn id="isolated-propid">&lt;isolation-mode></dfn> = auto | isolate</pre>
 
 <p id="img_isolation">
 In CSS, a background image or the content of an <a element>img</a> must always be rendered into an isolated group.<br>For instance, if you link to an SVG file through the <a element>img</a> tag, the artwork of that SVG will not blend with the backdrop of the content.</p>
@@ -350,7 +350,7 @@ This property takes the following value:
 
 The syntax of the property of <<composite-mode>> is given with:
 
-<pre class="compositemode"><dfn id="compositemode">&lt;composite-mode></dfn> = <a href="#porterduffcompositingoperators_clear">clear</a> | <a href="#porterduffcompositingoperators_src">copy</a> | <a href="#porterduffcompositingoperators_srcover">source-over</a> | <a href="#porterduffcompositingoperators_dstover">destination-over</a> | <a href="#porterduffcompositingoperators_srcin">source-in</a> | <br><a href="#porterduffcompositingoperators_dstin">destination-in</a> | <a href="#porterduffcompositingoperators_srcout">source-out</a> | <a href="#porterduffcompositingoperators_dstout">destination-out</a> | <a href="#porterduffcompositingoperators_srcatop">source-atop</a> | <br><a href="#porterduffcompositingoperators_dstatop">destination-atop</a> | <a href="#porterduffcompositingoperators_xor">xor</a> | <a href="#porterduffcompositingoperators_plus">lighter</a> | <a href="#porterduffcompositingoperators_plus_darker">plus-darker</a> | <a href="#porterduffcompositingoperators_plus_lighter">plus-lighter</a></pre>
+<pre class="compositemode prod"><dfn id="compositemode">&lt;composite-mode></dfn> = <a href="#porterduffcompositingoperators_clear">clear</a> | <a href="#porterduffcompositingoperators_src">copy</a> | <a href="#porterduffcompositingoperators_srcover">source-over</a> | <a href="#porterduffcompositingoperators_dstover">destination-over</a> | <a href="#porterduffcompositingoperators_srcin">source-in</a> | <br><a href="#porterduffcompositingoperators_dstin">destination-in</a> | <a href="#porterduffcompositingoperators_srcout">source-out</a> | <a href="#porterduffcompositingoperators_dstout">destination-out</a> | <a href="#porterduffcompositingoperators_srcatop">source-atop</a> | <br><a href="#porterduffcompositingoperators_dstatop">destination-atop</a> | <a href="#porterduffcompositingoperators_xor">xor</a> | <a href="#porterduffcompositingoperators_plus">lighter</a> | <a href="#porterduffcompositingoperators_plus_darker">plus-darker</a> | <a href="#porterduffcompositingoperators_plus_lighter">plus-lighter</a></pre>
 
 <h2 id="whatiscompositing">Introduction to compositing</h2>
 


### PR DESCRIPTION
blend-mode, isolation-mode and composite-mode production rules now have
the 'prod' CSS class, for easier identification by tools.

resolves #302