### PR TITLE
Remove sentence unnecessarily referencing "box types"

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -255,9 +255,7 @@ is ''1'', then this is a 2D transformation. Otherwise this is a 3D transformatio
 
 <h2 id=DOMRect>The DOMRect interfaces</h2>
 
-<p>Objects implementing the {{DOMRectReadOnly}} interface represent a <dfn>rectangle</dfn>. The type
-of box is specified by the method or attribute that returns a {{DOMRect}} or {{DOMRectReadOnly}}
-object.
+<p>Objects implementing the {{DOMRectReadOnly}} interface represent a <dfn>rectangle</dfn>.
 
 <p><a>Rectangles</a> have the following properties:
 


### PR DESCRIPTION
It is not necessary to mention that there are various other IDL methods in other specs which
return DOMRect or DOMRectReadOnly objects. The rect classes are well-defined on their own.