### PR TITLE
Replace links to w3c copy of canvas spec with links to living WHATWG spec

### DIFF
--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -14,7 +14,7 @@ Editor: Rik Cabanier, Adobe Systems Inc., cabanier@adobe.com, w3cid 106988
 Editor: Nikos Andronikos, Canon Information Systems Research Australia, Nikos.Andronikos@cisra.canon.com.au
 Abstract: Compositing describes how shapes of different elements are combined into a single image. There are various possible approaches for compositing. Previous versions of SVG and CSS used <a href="https://www.w3.org/TR/SVG11/masking.html#SimpleAlphaBlending">Simple Alpha Compositing</a>. In this model, each element is rendered into its own buffer and is then merged with its <a>backdrop</a> using the Porter Duff ''source-over'' operator. This specification will define a new compositing model that expands upon the Simple Alpha Compositing model by offering:
 Abstract: <ul><li>additional Porter Duff compositing operators</li><li>advanced blending modes which allow control of how colors mix in the areas where shapes overlap</li><li>compositing groups</li></ul>
-Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the <a href="https://www.w3.org/TR/2dcontext2/#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> attribute as defined in [[2DCONTEXT2]].
+Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> attribute as defined in [[2DCONTEXT2]].
 </pre>
 
 <style type="text/css">
@@ -49,7 +49,7 @@ The 'background-blend-mode' property also builds upon the properties defined in 
 
 This specification also enhances the rules as specified in <a href="https://www.w3.org/TR/2003/REC-SVG11-20030114/masking.html#SimpleAlphaBlending" title="simple alpha blending">Section 14.2 Simple alpha compositing</a> of [[SVG11]] and <a href="https://www.w3.org/TR/css3-color/#alpha" title="simple alpha compositing">simple alpha compositing</a> of [[!CSS3COLOR]].
 
-This module also extends the <a href="https://www.w3.org/TR/2dcontext2/#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> as defined in [[!2DCONTEXT2]].
+This module also extends the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> as defined in [[!2DCONTEXT2]].
 
 <h3 id="values">Values</h3>
 
@@ -324,7 +324,7 @@ Note that the gradient is not blending with the color of <a element>body</a>. In
 
 <h2 id="canvascompositingandblending">Specifying Compositing and Blending in Canvas 2D</h2>
 
-The <a href="https://www.w3.org/TR/2dcontext">canvas 2d</a> context defines the <a href="https://www.w3.org/TR/2dcontext/#dom-context-2d-globalcompositeoperation">‘globalCompositeOperation’</a> attribute that is used to set the current compositing and blending operator.
+The <a href="https://html.spec.whatwg.org/multipage/canvas.html#2dcontext">canvas 2d</a> context defines the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation">‘globalCompositeOperation’</a> attribute that is used to set the current compositing and blending operator.
 
 This property takes the following value:
 

--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -14,7 +14,7 @@ Editor: Rik Cabanier, Adobe Systems Inc., cabanier@adobe.com, w3cid 106988
 Editor: Nikos Andronikos, Canon Information Systems Research Australia, Nikos.Andronikos@cisra.canon.com.au
 Abstract: Compositing describes how shapes of different elements are combined into a single image. There are various possible approaches for compositing. Previous versions of SVG and CSS used <a href="https://www.w3.org/TR/SVG11/masking.html#SimpleAlphaBlending">Simple Alpha Compositing</a>. In this model, each element is rendered into its own buffer and is then merged with its <a>backdrop</a> using the Porter Duff ''source-over'' operator. This specification will define a new compositing model that expands upon the Simple Alpha Compositing model by offering:
 Abstract: <ul><li>additional Porter Duff compositing operators</li><li>advanced blending modes which allow control of how colors mix in the areas where shapes overlap</li><li>compositing groups</li></ul>
-Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> attribute as defined in [[2DCONTEXT2]].
+Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the {{globalCompositeOperation}} attribute.
 </pre>
 
 <style type="text/css">
@@ -49,7 +49,7 @@ The 'background-blend-mode' property also builds upon the properties defined in 
 
 This specification also enhances the rules as specified in <a href="https://www.w3.org/TR/2003/REC-SVG11-20030114/masking.html#SimpleAlphaBlending" title="simple alpha blending">Section 14.2 Simple alpha compositing</a> of [[SVG11]] and <a href="https://www.w3.org/TR/css3-color/#alpha" title="simple alpha compositing">simple alpha compositing</a> of [[!CSS3COLOR]].
 
-This module also extends the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> as defined in [[!2DCONTEXT2]].
+This module also extends the {{globalCompositeOperation}} attribute.
 
 <h3 id="values">Values</h3>
 
@@ -324,7 +324,7 @@ Note that the gradient is not blending with the color of <a element>body</a>. In
 
 <h2 id="canvascompositingandblending">Specifying Compositing and Blending in Canvas 2D</h2>
 
-The <a href="https://html.spec.whatwg.org/multipage/canvas.html#2dcontext">canvas 2d</a> context defines the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation">‘globalCompositeOperation’</a> attribute that is used to set the current compositing and blending operator.
+The <a href="https://html.spec.whatwg.org/multipage/canvas.html#2dcontext">canvas 2d</a> context defines the {{globalCompositeOperation}} attribute that is used to set the current compositing and blending operator.
 
 This property takes the following value:
 

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -14,7 +14,7 @@ Editor: Chris Harrelson, Google Inc., chrishtr@chromium.org, w3cid 90243
 Former Editor: Nikos Andronikos, Canon Information Systems Research Australia, Nikos.Andronikos@cisra.canon.com.au
 Abstract: Compositing describes how shapes of different elements are combined into a single image. There are various possible approaches for compositing. Previous versions of SVG and CSS used <a href="https://www.w3.org/TR/SVG11/masking.html#SimpleAlphaBlending">Simple Alpha Compositing</a>. In this model, each element is rendered into its own buffer and is then merged with its <a>backdrop</a> using the Porter Duff ''source-over'' operator. This specification will define a new compositing model that expands upon the Simple Alpha Compositing model by offering:
 Abstract: <ul><li>additional Porter Duff compositing operators</li><li>advanced blending modes which allow control of how colors mix in the areas where shapes overlap</li><li>compositing groups</li></ul>
-Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> attribute as defined in [[2DCONTEXT2]].
+Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the {{globalCompositeOperation}} attribute as defined in [[2DCONTEXT2]].
 </pre>
 
 <style type="text/css">
@@ -49,7 +49,8 @@ The 'background-blend-mode' property also builds upon the properties defined in 
 
 This specification also enhances the rules as specified in <a href="https://www.w3.org/TR/2003/REC-SVG11-20030114/masking.html#SimpleAlphaBlending" title="simple alpha blending">Section 14.2 Simple alpha compositing</a> of [[SVG11]] and <a href="https://www.w3.org/TR/css3-color/#alpha" title="simple alpha compositing">simple alpha compositing</a> of [[!CSS3COLOR]].
 
-This module also extends the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> as defined in [[!2DCONTEXT2]].
+This module also extends the 
+{{globalCompositeOperation}} as defined in [[!2DCONTEXT2]].
 
 <h3 id="values">Values</h3>
 
@@ -324,7 +325,7 @@ Note that the gradient is not blending with the color of <a element>body</a>. In
 
 <h2 id="canvascompositingandblending">Specifying Compositing and Blending in Canvas 2D</h2>
 
-The <a href="https://html.spec.whatwg.org/multipage/canvas.html#2dcontext">canvas 2d</a> context defines the <a href="https://www.w3.org/TR/2dcontext/#dom-context-2d-globalcompositeoperation">‘globalCompositeOperation’</a> attribute that is used to set the current compositing and blending operator.
+The <a href="https://html.spec.whatwg.org/multipage/canvas.html#2dcontext">canvas 2d</a> context defines the {{globalCompositeOperation}} attribute that is used to set the current compositing and blending operator.
 
 This property takes the following value:
 

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -14,7 +14,7 @@ Editor: Chris Harrelson, Google Inc., chrishtr@chromium.org, w3cid 90243
 Former Editor: Nikos Andronikos, Canon Information Systems Research Australia, Nikos.Andronikos@cisra.canon.com.au
 Abstract: Compositing describes how shapes of different elements are combined into a single image. There are various possible approaches for compositing. Previous versions of SVG and CSS used <a href="https://www.w3.org/TR/SVG11/masking.html#SimpleAlphaBlending">Simple Alpha Compositing</a>. In this model, each element is rendered into its own buffer and is then merged with its <a>backdrop</a> using the Porter Duff ''source-over'' operator. This specification will define a new compositing model that expands upon the Simple Alpha Compositing model by offering:
 Abstract: <ul><li>additional Porter Duff compositing operators</li><li>advanced blending modes which allow control of how colors mix in the areas where shapes overlap</li><li>compositing groups</li></ul>
-Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the {{globalCompositeOperation}} attribute as defined in [[2DCONTEXT2]].
+Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the {{globalCompositeOperation}} attribute.
 </pre>
 
 <style type="text/css">
@@ -50,7 +50,7 @@ The 'background-blend-mode' property also builds upon the properties defined in 
 This specification also enhances the rules as specified in <a href="https://www.w3.org/TR/2003/REC-SVG11-20030114/masking.html#SimpleAlphaBlending" title="simple alpha blending">Section 14.2 Simple alpha compositing</a> of [[SVG11]] and <a href="https://www.w3.org/TR/css3-color/#alpha" title="simple alpha compositing">simple alpha compositing</a> of [[!CSS3COLOR]].
 
 This module also extends the 
-{{globalCompositeOperation}} as defined in [[!2DCONTEXT2]].
+{{globalCompositeOperation}}.
 
 <h3 id="values">Values</h3>
 

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -14,7 +14,7 @@ Editor: Chris Harrelson, Google Inc., chrishtr@chromium.org, w3cid 90243
 Former Editor: Nikos Andronikos, Canon Information Systems Research Australia, Nikos.Andronikos@cisra.canon.com.au
 Abstract: Compositing describes how shapes of different elements are combined into a single image. There are various possible approaches for compositing. Previous versions of SVG and CSS used <a href="https://www.w3.org/TR/SVG11/masking.html#SimpleAlphaBlending">Simple Alpha Compositing</a>. In this model, each element is rendered into its own buffer and is then merged with its <a>backdrop</a> using the Porter Duff ''source-over'' operator. This specification will define a new compositing model that expands upon the Simple Alpha Compositing model by offering:
 Abstract: <ul><li>additional Porter Duff compositing operators</li><li>advanced blending modes which allow control of how colors mix in the areas where shapes overlap</li><li>compositing groups</li></ul>
-Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the <a href="https://www.w3.org/TR/2dcontext2/#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> attribute as defined in [[2DCONTEXT2]].
+Abstract: In addition, this specification will define CSS properties for blending and group isolation and the properties of the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> attribute as defined in [[2DCONTEXT2]].
 </pre>
 
 <style type="text/css">
@@ -49,7 +49,7 @@ The 'background-blend-mode' property also builds upon the properties defined in 
 
 This specification also enhances the rules as specified in <a href="https://www.w3.org/TR/2003/REC-SVG11-20030114/masking.html#SimpleAlphaBlending" title="simple alpha blending">Section 14.2 Simple alpha compositing</a> of [[SVG11]] and <a href="https://www.w3.org/TR/css3-color/#alpha" title="simple alpha compositing">simple alpha compositing</a> of [[!CSS3COLOR]].
 
-This module also extends the <a href="https://www.w3.org/TR/2dcontext2/#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> as defined in [[!2DCONTEXT2]].
+This module also extends the <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation" title="canvas 2d globalcompositeoperation">‘globalcompositeoperation’</a> as defined in [[!2DCONTEXT2]].
 
 <h3 id="values">Values</h3>
 
@@ -324,7 +324,7 @@ Note that the gradient is not blending with the color of <a element>body</a>. In
 
 <h2 id="canvascompositingandblending">Specifying Compositing and Blending in Canvas 2D</h2>
 
-The <a href="https://www.w3.org/TR/2dcontext">canvas 2d</a> context defines the <a href="https://www.w3.org/TR/2dcontext/#dom-context-2d-globalcompositeoperation">‘globalCompositeOperation’</a> attribute that is used to set the current compositing and blending operator.
+The <a href="https://html.spec.whatwg.org/multipage/canvas.html#2dcontext">canvas 2d</a> context defines the <a href="https://www.w3.org/TR/2dcontext/#dom-context-2d-globalcompositeoperation">‘globalCompositeOperation’</a> attribute that is used to set the current compositing and blending operator.
 
 This property takes the following value:
 


### PR DESCRIPTION
This fixes #267 