### PR TITLE
[filter-effects] initial value linearRGB

### DIFF
--- a/filter-effects/Overview.bs
+++ b/filter-effects/Overview.bs
@@ -3035,7 +3035,7 @@ The description of the 'color-interpolation-filters' property is as follows:
 <pre class='propdef'>
 Name: color-interpolation-filters
 Value: auto | sRGB | linearRGB
-Initial: auto
+Initial: linearRGB
 Applies to: All <a>filter primitives</a>
 Inherited: yes
 Percentages: n/a


### PR DESCRIPTION
color-interpolation-filters has an initial value linearRGB,
as was specified in SVG 1.1 as as implemented in browsers.

Discussed in https://github.com/w3c/csswg-drafts/issues/3131