### PR TITLE
[motion] reverse does not appear in computed value

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -1049,7 +1049,7 @@ Initial: auto
 Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Inherited: no
 Percentages: n/a
-Computed value: as specified
+Computed value: computed <<angle>> value, optionally preceded by auto
 Media: visual
 Animatable: yes
 </pre>


### PR DESCRIPTION
reverse is equivalent to auto 180deg.

The computed value only uses auto.

WPT https://github.com/web-platform-tests/wpt/pull/13820