### PR TITLE
Clip backdrop root (input) image to border box of element

### DIFF
--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -93,10 +93,11 @@ be seen, you can use "background-color: transparent;".
 
 # Backdrop Root # {#BackdropRoot}
 
-The <dfn>Backdrop Root Image</dfn> for an element E is defined as the image produced by:
-1. Starting at the <a>Backdrop Root</a> element that is the nearest ancestor of E.
-2. Painting all content, in <a href="https://www.w3.org/TR/CSS2/zindex.html#painting-order">painting order</a>, between (and including) the ancestor Backdrop Root element and element E.
-3. Clipping this final painted output to the border box of element E.
+The <dfn>Backdrop Root Image</dfn> for an element E is the final image that would be produced by the following steps:
+1. Start at the <a>Backdrop Root</a> element that is the nearest ancestor of E.
+2. Paint all content, in <a href="https://www.w3.org/TR/CSS2/zindex.html#painting-order">painting order</a>, between (and including) the ancestor Backdrop Root element and element E.
+3. Flatten the painted content into a 2D screen-space buffer.
+4. Transform the border box of element E to 2D screen-space, and clip the final painted output to this border quad.
 
 Note: No content that is a DOM ancestor of the Backdrop Root element should
 contribute to or affect the Backdrop Root Image.

--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -78,6 +78,10 @@ output as its SourceGraphic.
 
 Filter functions must operate in the sRGB color space.
 
+If the filter functions list includes a <a href="https://drafts.fxtf.org/filter-effects-1/#blurEquivalent">blur()</a>
+filter, the blur filter will be applied with edgeMode="duplicate", with the edge defined by the transformed border
+box of the element. See [[#BackdropRoot]].
+
 A computed value of other than ''backdrop-filter/none'' results in the
 creation of both a <a href="https://www.w3.org/TR/CSS21/zindex.html">stacking
 context</a> [[!CSS21]] and a <a

--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -79,7 +79,7 @@ output as its SourceGraphic.
 Filter functions must operate in the sRGB color space.
 
 If the filter functions list includes a <a href="https://drafts.fxtf.org/filter-effects-1/#blurEquivalent">blur()</a>
-filter, the blur filter will be applied with edgeMode="duplicate", with the edge defined by the clipped, transformed border
+filter (or other pixel-moving filter), the filter will be applied with edgeMode="duplicate", with the edge defined by the clipped, transformed border
 box of the element. See [[#BackdropRoot]].
 
 A computed value of other than ''backdrop-filter/none'' results in the

--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -79,7 +79,7 @@ output as its SourceGraphic.
 Filter functions must operate in the sRGB color space.
 
 If the filter functions list includes a <a href="https://drafts.fxtf.org/filter-effects-1/#blurEquivalent">blur()</a>
-filter (or other pixel-moving filter), the filter will be applied with edgeMode="duplicate", with the edge defined by the clipped, transformed border
+filter, the filter will be applied with edgeMode="duplicate", with the edge defined by the clipped, transformed border
 box of the element. See [[#BackdropRoot]].
 
 A computed value of other than ''backdrop-filter/none'' results in the

--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -79,7 +79,7 @@ output as its SourceGraphic.
 Filter functions must operate in the sRGB color space.
 
 If the filter functions list includes a <a href="https://drafts.fxtf.org/filter-effects-1/#blurEquivalent">blur()</a>
-filter, the blur filter will be applied with edgeMode="duplicate", with the edge defined by the transformed border
+filter, the blur filter will be applied with edgeMode="duplicate", with the edge defined by the clipped, transformed border
 box of the element. See [[#BackdropRoot]].
 
 A computed value of other than ''backdrop-filter/none'' results in the

--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -93,13 +93,13 @@ be seen, you can use "background-color: transparent;".
 
 # Backdrop Root # {#BackdropRoot}
 
-The <dfn>Backdrop Root Image</dfn> is defined as the entire painted output produced by
-drawing, in <a
-href="https://www.w3.org/TR/CSS2/zindex.html#painting-order">painting order</a>,
-all content between (and including) the <a>Backdrop Root</a> element and the
-child element that needs access to the "backdrop". No content that is a DOM
-ancestor of the Backdrop Root element should contribute to or affect the
-Backdrop Root Image.
+The <dfn>Backdrop Root Image</dfn> for an element E is defined as the image produced by:
+1. Starting at the <a>Backdrop Root</a> element that is the nearest ancestor of E.
+2. Painting all content, in <a href="https://www.w3.org/TR/CSS2/zindex.html#painting-order">painting order</a>, between (and including) the ancestor Backdrop Root element and element E.
+3. Clipping this final painted output to the border box of element E.
+
+Note: No content that is a DOM ancestor of the Backdrop Root element should
+contribute to or affect the Backdrop Root Image.
 
 A <dfn>Backdrop Root</dfn> is formed, anywhere in the document, by an element in any of the following scenarios. See [[#BackdropRootTriggers]] for more details on each:
  * The root element of the document (HTML).


### PR DESCRIPTION
With this change, the spec is now explicit that the input image for the backdrop root image should be clipped to the border box of the element. Prior to this change, the spec was written such that the
entire backdrop image was to be used as the filter input. For filters that move pixels (e.g. blur), this
meant that neighboring content that is outside the bounds of the element would influence the filtered
content within the element's bounds.

This change is a good one for these reasons:
 - It agrees more closely with existing Webkit/Safari behavior.
 - It improves performance, by filtering fewer pixels in the
   case of pixel-moving filters.
 - Developers have been disappointed with the existing behavior
   of bringing in pixels from outside the bounds of the
   element, and have requested a way to turn this behavior off.
   See the discussion starting at [1].