### PR TITLE
Link to crossorigin attr in HTML LS

### DIFF
--- a/filter-effects/Overview.bs
+++ b/filter-effects/Overview.bs
@@ -643,13 +643,13 @@ Most filter primitives take other filter primitives as input. The following attr
     : <dfn>in</dfn> = "<em><a attr-value>SourceGraphic</a> | <a attr-value>SourceAlpha</a> | <a attr-value>BackgroundImage</a> | <a attr-value>BackgroundAlpha</a> | <a attr-value>FillPaint</a> | <a attr-value>StrokePaint</a> | <<filter-primitive-reference>></em>"
     ::
         Identifies input for the given filter primitive. The value can be either one of six keywords or can be a string which matches a previous <a element-attr>result</a> attribute value within the same <a element>filter</a> element. If no value is provided and this is the first <a>filter primitive</a>, then this <a>filter primitive</a> will use <a attr-value>SourceGraphic</a> as its input. If no value is provided and this is a subsequent <a>filter primitive</a>, then this <a>filter primitive</a> will use the result from the previous <a>filter primitive</a> as its input.
-        
+
         If the value for <a element-attr for=filter-primitive>result</a> appears multiple times within a given <a element>filter</a> element, then a reference to that result will use the closest preceding <a>filter primitive</a> with the given value for attribute <a element-attr>result</a>.
-        
+
         Forward references to results are not allowed, and will be treated as if no result was specified.
-        
+
         References to non-existent results will be treated as if no result was specified.
-        
+
         Definitions for the six keywords:
         <dl dfn-type=attr-value dfn-for=in>
             : <dfn>SourceGraphic</dfn>
@@ -658,7 +658,7 @@ Most filter primitives take other filter primitives as input. The following attr
             : <dfn>SourceAlpha</dfn>
             ::
                 This keyword represents the graphics elements that were the original input into the <a element>filter</a> element. <a attr-value>SourceAlpha</a> has all of the same rules as <a attr-value>SourceGraphic</a> except that only the alpha channel is used. The input image is an RGBA image consisting of implicitly black color values for the RGB channels, but whose alpha channel is the same as <a attr-value>SourceGraphic</a>.
-                
+
                 Note: If this option is used, then some implementations might need to rasterize the graphics elements in order to extract the alpha channel.
             : <dfn>BackgroundImage</dfn>
             ::
@@ -761,7 +761,7 @@ All intermediate offscreens are defined to not exceed the intersection of the <a
                &lt;/feMerge&gt;
             &lt;/filter&gt;
           &lt;/defs&gt;
-        
+
           &lt;g fill="none" stroke="blue" stroke-width="4"&gt;
              &lt;rect width="200" height="200"/&gt;
              &lt;line x2="200" y2="200"/&gt;
@@ -793,7 +793,7 @@ All intermediate offscreens are defined to not exceed the intersection of the <a
         <img alt="Example for subregions" src="examples/filtersubregion00.png">
         <p class=caption>Example for subregions</p>
     </div>
-    
+
     <a href="examples/filtersubregion00.svg">View this example as SVG</a>
 
     In the example above there are three rectangles that each have a cross and a circle in them. The circle element in each one has a different filter applied, but with the same <a>filter primitive subregion</a>. The filter output should be limited to the <a>filter primitive subregion</a> so you should never see the circles themselves, just the rectangles that make up the <a>filter primitive subregion</a>.
@@ -925,7 +925,7 @@ The calculations are performed on non-premultiplied color values.
     : <dfn>type</dfn> = "<span dfn-type=attr-value dfn-for=type><dfn>matrix</dfn> | <dfn>saturate</dfn> | <dfn>hueRotate</dfn> | <dfn>luminanceToAlpha</dfn></span>"
     ::
         Indicates the type of matrix operation. The keyword <a attr-value>matrix</a> indicates that a full 5x4 matrix of values will be provided. The other keywords represent convenience shortcuts to allow commonly used color operations to be performed without specifying a complete matrix.
-        
+
         The <a for=svg>initial value</a> for <a element-attr for=feColorMatrix>type</a> is <a attr-value>matrix</a>.
 
         Animatable: yes.
@@ -1132,16 +1132,16 @@ The attributes below are the <dfn id="transfer-function-element-attributes">tran
             For a value <code>C &lt; 1</code> find <code>k</code> such that:
 
             <code>k/n &lt;= C &lt; (k+1)/n</code>
-            
+
             The result <code>C'</code> is given by:
 
             <code>C' = v<sub>k</sub> + (C - k/n)*n * (v<sub>k+1</sub> - v<sub>k</sub>)</code>
-        
+
             If <code>C = 1</code> then:
 
             <code>C' = v<sub>n</sub>.</code>
         * For <dfn attr-value for=type>discrete</dfn>, the function is defined by the step function given in the attribute <a element-attr>tableValues</a>, which provides a list of <em>n</em> values (i.e., v<sub>0</sub> to v<sub>n-1</sub>) in order to identify a step function consisting of <em>n</em> steps. The step function is defined by the following formula:
- 
+
             For a value <code>C &lt; 1</code> find <code>k</code> such that:
 
             <code>k/n &lt;= C &lt; (k+1)/n</code>
@@ -1166,7 +1166,7 @@ The attributes below are the <dfn id="transfer-function-element-attributes">tran
     : <dfn>tableValues</dfn> = "<em>(list of <<number>>s)</em>"
     ::
         When <code>type="table"</code>, the list of <<number>> s <em>v0,v1,...vn</em>, separated by white space and/or a comma, which define the lookup table. An empty list results in an identity transfer function.
-        
+
         If the attribute is not specified, then the effect is as if an empty list were provided.
 
         Animatable: yes.</p>
@@ -1477,7 +1477,7 @@ Note: Compositing and Blending [[!COMPOSITING-1]] defines more compositing keywo
               &lt;use transform="translate(900,25)" xlink:href="#TwoBlueTriangles"/&gt;
             &lt;/g&gt;
           &lt;/defs&gt;
-        
+
           &lt;rect fill="none" stroke="blue" x="1" y="1" width="1098" height="648"/&gt;
           &lt;g font-family="Verdana" font-size="40" shape-rendering="crispEdges"&gt;
             &lt;desc&gt;Render the examples using the filters that draw on top of
@@ -1637,7 +1637,7 @@ When the image must be resampled to match the coordinate system defined by <a el
     : <dfn>divisor</dfn> = "<em><<number>></em>"
     ::
         After applying the <a element-attr>kernelMatrix</a> to the input image to yield a number, that number is divided by <a element-attr>divisor</a> to yield the final destination color value. A divisor that is the sum of all the matrix values tends to have an evening effect on the overall color intensity of the result. If the specified divisor is ''0'' then the default value will be used instead.
-        
+
         The <a for=svg>initial value</a> is the sum of all values in <a element-attr>kernelMatrix</a>, with the exception that if the sum is zero, then the divisor is set to ''1''.
 
         Animatable: yes.
@@ -1656,18 +1656,18 @@ When the image must be resampled to match the coordinate system defined by <a el
     : <dfn>targetY</dfn> = "<<integer>>"
     ::
         Determines the positioning in Y of the convolution matrix relative to a given target pixel in the input image. The topmost row of the matrix is row number zero. The value must be such that: 0 &lt;= targetY &lt; orderY. By default, the convolution matrix is centered in Y over each pixel of the input image (i.e., targetY = floor ( orderY / 2 )).</p>
-    
+
         Animatable: yes.
     : <dfn>edgeMode</dfn> = "<a attr-value>duplicate</a> | <a attr-value>wrap</a> | none</span>"
     ::
         Determines how to extend the input image as necessary with color values so that the matrix operations can be applied when the kernel is positioned at or near the edge of the input image.
-    
+
         ''duplicate'' indicates that the input image is extended along each of its borders as necessary by duplicating the color values at the given edge of the input image.
 
         Original N-by-M image, where m=M-1 and n=N-1:
 
         <pre class=include>path: mathml/feConvolveMatrix04.mml</pre>
-  
+
         Extended by two pixels using ''duplicate'':
 
         <pre class=include>path: mathml/feConvolveMatrix05.mml</pre>
@@ -2106,19 +2106,19 @@ The 'color-interpolation-filters' property only applies to the <a element-attr f
         Indicates which channel from <a element-attr for=feDisplacementMap>in2</a> to use to displace the pixels in <a element-attr>in</a> along the x-axis.
 
         The <a for=svg>initial value</a> for <a element-attr>xChannelSelector</a> is ''A''.
-        
+
         Animatable: yes.
     : <dfn>yChannelSelector</dfn> = "<em>R | G | B | A</em>"
     ::
         Indicates which channel from <a element-attr for=feDisplacementMap>in2</a> to use to displace the pixels in <a element-attr>in</a> along the y-axis.
 
         The <a for=svg>initial value</a> for <a element-attr>yChannelSelector</a> is ''A''.
-        
+
         Animatable: yes.</p>
     : <dfn>in2</dfn> = "<em>(see <a element-attr>in</a> attribute)</em>"
     ::
         The second input image, which is used to displace the pixels in the image from attribute <a element-attr>in</a>. See defintion for <a element-attr>in</a> attribute.
-        
+
         Animatable: yes.
 </dl>
 
@@ -2318,15 +2318,15 @@ Frequently this operation will take place on alpha-only images, such as that pro
     : <dfn>edgeMode</dfn> = "<a attr-value>duplicate</a> | <a attr-value>wrap</a> | none"
     ::
         Determines how to extend the input image as necessary with color values so that the matrix operations can be applied when the kernel is positioned at or near the edge of the input image.
-        
+
         <dfn dfn-type=attr-value dfn-for=edgeMode>duplicate</dfn> indicates that the input image is extended along each of its borders as necessary by duplicating the color values at the given edge of the input image.
-        
+
         Original N-by-M image, where m=M-1 and n=N-1:
-        
+
         <dfn dfn-type=attr-value dfn-for=edgeMode>wrap</dfn> indicates that the input image is extended by taking the color values from the opposite edge of the image.
-        
+
         The value ''feGaussianBlur/none'' indicates that the input image is extended with pixel values of zero for R, G, B and A.
-        
+
         The <a for=svg>initial value</a> for <a element-attr for=feGaussianBlur>edgeMode</a> is ''feGaussianBlur/none''.
 
         Animatable: yes.
@@ -2379,7 +2379,7 @@ A <a element-attr for=feImage>href</a> reference that is an empty image (zero wi
         Animatable: yes.
     : <dfn>crossorigin</dfn> = "<em>anonymous</em> | <em>use-credentials</em>"
     ::
-        The <a href="https://www.w3.org/TR/html5/infrastructure.html#cors-settings-attribute">crossorigin</a> attribute is a CORS settings attribute. Its purpose is to allow images from third-party sites that allow cross-origin access to be used with <a element>feDisplacementMap</a>. For the defintion see <a href="https://www.w3.org/TR/html5/infrastructure.html#cors-settings-attribute">crossorigin</a> attribute for the <a element>img</a> tag [[!HTML5]] and the <a href="#priv-sec">Privacy and Security Considerations</a> section in this specification.
+        The <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-crossorigin">crossorigin</a> attribute is a CORS settings attribute. Its purpose is to allow images from third-party sites that allow cross-origin access to be used with <a element>feDisplacementMap</a>. For the defintion see <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-crossorigin">crossorigin</a> attribute for the <a element>img</a> tag [[!HTML]] and the <a href="#priv-sec">Privacy and Security Considerations</a> section in this specification.
 
         Animatable: no.
 </dl>
@@ -2495,14 +2495,14 @@ Because <a element>feMorphology</a> operates on premultipied color values, it wi
     : <dfn>operator</dfn> = "<em>erode | dilate</em>"
     ::
         A keyword indicating whether to erode (i.e., thin) or dilate (fatten) the source graphic.
-        
+
         The <a for=svg>initial value</a> for <a element-attr for=feMorphology>operator</a> is ''erode''.
-  
+
         Animatable: yes.
     : <dfn>radius</dfn> = "<em><<number-optional-number>></em>"
     ::
         The radius (or radii) for the operation. If two <<number>> s are provided, the first number represents a x-radius and the second value represents a y-radius. If one number is provided, then that value is used for both X and Y. The values are in the coordinate system established by attribute <a element-attr>primitiveUnits</a> on the <a element>filter</a> element.
-        
+
         A negative or zero value disables the effect of the given filter primitive (i.e., the result is the filter input image).
 
         The <a for=svg>initial value</a> for <a element-attr for=feMorphology>radius</a> is ''0''.
@@ -2665,7 +2665,7 @@ The <a element>feDiffuseLighting</a> and <a element>feSpecularLighting</a> filte
     : <dfn>kernelUnitLength</dfn> = "<em><<number-optional-number>></em>"
     ::
         The first number is the &lt;dx&gt; value. The second number is the &lt;dy&gt; value.
-        
+
         If the &lt;dy&gt; value is not specified, it defaults to the same value as &lt;dx&gt;. Indicates the intended distance in current filter units (i.e., units as determined by the value of attribute <a element-attr>primitiveUnits</a>) for <code>dx</code> and <code>dy</code>, respectively, in the <a href="#SurfaceNormalCalculations">surface normal calculation formulas</a>. By specifying value(s) for <a element-attr for=feSpecularLighting>kernelUnitLength</a>, the kernel becomes defined in a scalable, abstract coordinate system.
 
         If <a element-attr for=feSpecularLighting>kernelUnitLength</a> is not specified, the <code>dx</code> and <code>dy</code> values should represent very small deltas relative to a given <code>(x,y)</code> position, which might be implemented in some cases as one pixel in the intermediate image offscreen bitmap, which is a pixel-based coordinate system, and thus potentially not scalable. For some level of consistency across display media and user agents, it is necessary that a value be provided for <a element-attr for=feSpecularLighting>kernelUnitLength</a>.
@@ -2912,18 +2912,18 @@ double turbulence(int nColorChannel, double *point, double fBaseFreqX, double fB
     : <dfn>baseFrequency</dfn> = "<em><<number-optional-number>></em>"
     ::
         The base frequency (frequencies) parameter(s) for the noise function. If two <<number>>s are provided, the first number represents a base frequency in the X direction and the second value represents a base frequency in the Y direction. If one number is provided, then that value is used for both X and Y.
-        
+
         The <a for=svg>initial value</a> for <a element-attr>baseFrequency</a> is ''0''.
-        
+
         Negative values are <a>unsupported</a>.
-        
+
         Animatable: yes.
     : <dfn>numOctaves</dfn> = "<em><<integer>></em>"
     ::
         The numOctaves parameter for the noise function.
 
         The <a for=svg>initial value</a> for <a element-attr>numOctaves</a> is ''1''.
-        
+
         Negative values are <a>unsupported</a>.
 
         Animatable: yes.
@@ -2932,11 +2932,11 @@ double turbulence(int nColorChannel, double *point, double fBaseFreqX, double fB
     : <dfn>seed</dfn> = "<em><<number>></em>"
     ::
         The starting number for the pseudo random number generator.
-        
+
         The <a for=svg>initial value</a> for <a element-attr>seed</a> is ''0''.
-        
+
         When the seed number is handed over to the algorithm above it must first be truncated, i.e. rounded to the closest integer value towards zero.
-        
+
         Animatable: yes.
     : <dfn>stitchTiles</dfn> = "<em>stitch | noStitch</em>"
     ::
@@ -2990,35 +2990,35 @@ double turbulence(int nColorChannel, double *point, double fBaseFreqX, double fB
                 &lt;feTurbulence type="fractalNoise" baseFrequency="0.1" numOctaves="1"/&gt;
               &lt;/filter&gt;
             &lt;/defs&gt;
-          
+
             &lt;rect x="1" y="1" width="448" height="323"
                   fill="none" stroke="blue" stroke-width="1"  /&gt;
-                
+
             &lt;rect x="25" y="25" width="100" height="75" filter="url(#Turb1)"  /&gt;
             &lt;text x="75" y="117"&gt;type=turbulence&lt;/text&gt;
             &lt;text x="75" y="129"&gt;baseFrequency=0.05&lt;/text&gt;
             &lt;text x="75" y="141"&gt;numOctaves=2&lt;/text&gt;
-          
+
             &lt;rect x="175" y="25" width="100" height="75" filter="url(#Turb2)"  /&gt;
             &lt;text x="225" y="117"&gt;type=turbulence&lt;/text&gt;
             &lt;text x="225" y="129"&gt;baseFrequency=0.1&lt;/text&gt;
             &lt;text x="225" y="141"&gt;numOctaves=2&lt;/text&gt;
-          
+
             &lt;rect x="325" y="25" width="100" height="75" filter="url(#Turb3)"  /&gt;
             &lt;text x="375" y="117"&gt;type=turbulence&lt;/text&gt;
             &lt;text x="375" y="129"&gt;baseFrequency=0.05&lt;/text&gt;
             &lt;text x="375" y="141"&gt;numOctaves=8&lt;/text&gt;
-          
+
             &lt;rect x="25" y="180" width="100" height="75" filter="url(#Turb4)"  /&gt;
             &lt;text x="75" y="272"&gt;type=fractalNoise&lt;/text&gt;
             &lt;text x="75" y="284"&gt;baseFrequency=0.1&lt;/text&gt;
             &lt;text x="75" y="296"&gt;numOctaves=4&lt;/text&gt;
-          
+
             &lt;rect x="175" y="180" width="100" height="75" filter="url(#Turb5)"  /&gt;
             &lt;text x="225" y="272"&gt;type=fractalNoise&lt;/text&gt;
             &lt;text x="225" y="284"&gt;baseFrequency=0.4&lt;/text&gt;
             &lt;text x="225" y="296"&gt;numOctaves=4&lt;/text&gt;
-          
+
             &lt;rect x="325" y="180" width="100" height="75" filter="url(#Turb6)"  /&gt;
             &lt;text x="375" y="272"&gt;type=fractalNoise&lt;/text&gt;
             &lt;text x="375" y="284"&gt;baseFrequency=0.1&lt;/text&gt;
@@ -3101,7 +3101,7 @@ macros:
     : <dfn>elevation</dfn> = "<em><<number>></em>"
     ::
         Direction angle for the light source from the XY plane towards the Z-axis, in degrees. Note that the positive Z-axis points towards the viewer.
-        
+
         The <a for=svg>initial value</a> for <a element-attr>elevation</a> is ''0''.
 
         Animatable: yes.


### PR DESCRIPTION
Link to HTML LS, rather than HTML 5.x, for definition of the `crossorigin` attribute.

(Also a bunch of trailing-whitespace cleanup, good to do but sorry for the noise in this PR, my editor does it automatically)