### PR TITLE
Don't distinguish between unspecified and empty DomQuadInit fields

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -425,10 +425,10 @@ interface DOMQuad {
 };
 
 dictionary DOMQuadInit {
-  DOMPointInit p1;
-  DOMPointInit p2;
-  DOMPointInit p3;
-  DOMPointInit p4;
+  DOMPointInit p1 = null;
+  DOMPointInit p2 = null;
+  DOMPointInit p3 = null;
+  DOMPointInit p4 = null;
 };
 </pre>
 


### PR DESCRIPTION
Fixes #349 

Unsure if this should be null or an empty dict, I feel both have the same effect.


r? @zcorpan cc @bzbarsky