### PR TITLE
Fix the backdrop-filter order of operations to get opacity right

### DIFF
--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -60,11 +60,12 @@ An element (call it B) with a backdrop-filter property other than ''backdrop-fil
 the following steps are performed:
 1. Copy the <a>Backdrop Root Image</a> into a temporary buffer, such as a raster image. Call this buffer T’.
 2. Apply the backdrop-filter’s filter operations to the entire contents of T'.
-3. If element B has any transforms (between B and the Backdrop Root), apply the <b>inverse</b> of those transforms to the contents of T’.
-4. Apply a clip to the contents of T’, using the border box of element B, including <a href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a> if specified. Note that the children of B are not considered for the sizing or location of this clip.
-5. Draw all of element B, including its background, border, and any children elements, into T’.
-6. If element B has any transforms, effects, or clips, apply those to T’.
-7. Composite the contents of T’ into element B's parent, using source-over compositing.
+3. If element B has any effects, opacity, or clips, apply those to T’.
+4. Apply a clip to the contents of T’, using the transformed border box of element B, including <a href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">border-radius</a> if specified. Note that the children of B are not considered for the sizing or location of this clip.
+5. Composite the contents of T’ into element B's parent, using source-over compositing.
+6. Draw all of element B, including its background, border, and any children elements, into another temporary buffer B'.
+7. If element B has any transforms, effects, opacity, or clips, apply those to B’.
+8. Composite the contents of B’ into element B's parent, using source-over compositing.
 
 <pre class=link-defaults>
   spec:filter-effects-1; type:element; text:filter


### PR DESCRIPTION
With the previous description, opacity was implicitly included in the final set of filters applied to all content. But that's incorrect, at least according to expectation and behavior. Opacity is special here - it needs to be separately applied to the filtered backdrop, because if it is applied only at the end, the fully-opaque contents of B will have already painted over the filtered backdrop. There won't be any show-through of the backdrop, even though the expectation is to see it, given that opacity is less than 1.
While that change is being made, I've also copied the other effects and clips to the backdrop-filtered image as well. These could possibly be defined to only apply once at the end, but the resulting image will be identical or nearly-so, and in practice, the implementation is typically closer to this new definition.