### PR TITLE
Added more issue markers for the lack of consensus on backdrop root

### DIFF
--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -30,7 +30,7 @@ filter effect, or provided as a CSS image value.
 This is Level 2 of the Filter Effects Module. It is currently written as
 a "delta", describing any differences from Level 1.
 
-Issue: This specification drafted for discussion and does not yet have Working Group consensus.
+Issue: This specification was drafted for discussion, and does not yet have Working Group consensus.
 See <a href="https://github.com/w3c/fxtf-drafts/issues/53">discussion in issue 53</a>.
 
 
@@ -103,6 +103,9 @@ The <dfn>Backdrop Root Image</dfn> for an element E is the final image that woul
 2. Paint all content, in <a href="https://www.w3.org/TR/CSS2/zindex.html#painting-order">painting order</a>, between (and including) the ancestor Backdrop Root element and element E.
 3. Flatten the painted content into a 2D screen-space buffer.
 4. Transform the border box of element E to 2D screen-space, and clip the final painted output to this border quad.
+
+Issue: This specification does not yet have Working Group consensus, specifically on the definition of Backdrop Root.
+See <a href="https://github.com/w3c/fxtf-drafts/issues/53">discussion in issue 53</a>.
 
 Note: No content that is a DOM ancestor of the Backdrop Root element should
 contribute to or affect the Backdrop Root Image.
@@ -309,6 +312,9 @@ performance breakdown. Clearly, this is not a scalable approach.
 ## Backdrop Root Triggers ## {#BackdropRootTriggers}
 
 <em>This section is non-normative</em>
+
+Issue: This specification does not yet have Working Group consensus, specifically on the definition of Backdrop Root.
+See <a href="https://github.com/w3c/fxtf-drafts/issues/53">discussion in issue 53</a>.
 
 As described in [[#BackdropRootMotivation]], several operations pose fundamental problems for operations that need to read back content that was painted before, and then re-paint that content (possibly filtered or blended) again. The list of element types that trigger a [[#BackdropRoot]] each pose one of these problems. Some are obvious and some are more nuanced. This section describes why each trigger is necessary.
 


### PR DESCRIPTION
Per [request from TAG](https://github.com/w3ctag/design-reviews/issues/353#issuecomment-530180965), I've added two more red "Issue" markers at the Backdrop Root definition, and the discussion of Backdrop Root Triggers.