### PR TITLE
Fix text to specify correct blend-mode on the root element

### DIFF
--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -715,7 +715,7 @@ applied, before compositing into the <a href="#rootgroup">root group</a>.
 The root group is the final isolated group, and is is below the root
 element group.
 
-<p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-3/#sample">white, 100% opaque</a> root group,
+<p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-4/#sample">white, 100% opaque</a> root group,
 for final compositing, but this is not required. For example, an iframe may
 have a transparent background, and therefore the root group contains content
 from an ancestor document.

--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -82,6 +82,8 @@ Everything in CSS that creates a <a href="https://www.w3.org/TR/CSS21/zindex.htm
 
 An element that has blending applied, must blend with all the underlying content of the <a spec="css21">stacking context</a> [[!CSS21]] that that element belongs to.
 
+The root element for an HTML document is the <a href="https://dom.spec.whatwg.org/#document-element">document element</a>.
+
 <h3 id="csscompositingrules_SVG">Behavior specific to SVG</h3>
 
 By default, every element must create a <a href="#isolatedgroups">non-isolated group</a>.
@@ -97,6 +99,8 @@ However, certain operations in SVG will create <a href="#isolatedgroups">isolate
 <li>blending</li>
 <li>masking</li>
 </ul>
+
+The root element for SVG is the <a href="https://www.w3.org/TR/SVG11/struct.html#NewDocument">SVG element</a>.
 
 <h3 id="csskeywords">CSS Properties</h3>
 
@@ -700,20 +704,21 @@ On the left, the group has the 'knock-out' property activated. On the right, the
 If the 'knock-out' property is disabled, each element within the group is only composited with the elements underneath the group.
 </p>
 -->
-<h3 id="pagebackdrop">The Page Group</h3>
+<h3 id="pagebackdrop">The Root Element Group</h3>
 
 The <a href="#isolatedgroups">isolated group</a> for the root element is the
-page group. All other elements and groups are composited into this group.
-The background of the root element (if specified) is painted into the page
-group, and any filter, clip-path, mask and and opacity is then applied, before
-compositing into the <a href="#rootgroup">root group</a>.
+root element group. All other elements and groups are composited into this group. The background of the root element (if specified) is painted into the
+root element group, and any filter, clip-path, mask and and opacity is then
+applied, before compositing into the <a href="#rootgroup">root group</a>.
 
 <h3 id="rootgroup">The Root Group</h3>
-The root group is the final compositing output, and is is above the page
-group.
+The root group is the final compositing output, and is is below the root
+element group.
 
 <p class="note">Browsers often use an infinite white, 100% opaque root group,
-for final compositing, but this is not required. One example is an iframe with a transparent background.
+for final compositing, but this is not required. For example, an iframe may
+have a transparent background, and therefore the root group contains content
+from an ancestor document.
 
 <h2 id="advancedcompositing">Advanced compositing features</h2>
 

--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -709,15 +709,14 @@ If the 'knock-out' property is disabled, each element within the group is only c
 The <a href="#isolatedgroups">isolated group</a> for the root element is the
 root element group. All other elements and groups are composited into this group. The background of the root element (if specified) is painted into the
 root element group, and any filter, clip-path, mask and and opacity is then
-applied, before compositing into the <a href="#rootgroup">root group</a>.
+applied, before compositing into the <a href="#rootgroup">root group</a>,
+if present.
 
 <h3 id="rootgroup">The Root Group</h3>
-The root group encompasses the entire canvas and contains (or is below) the page group.
+The root group encompasses the entire canvas and contains (or is below) the root element group of the root element of a web page.
 
 <p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-4/#sample">white, 100% opaque</a> root group,
-for final compositing, but this is not required. For example, an iframe may
-have a transparent background, and therefore the root group contains content
-from an ancestor document.
+for final compositing, but this is not required.
 
 <h2 id="advancedcompositing">Advanced compositing features</h2>
 

--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -712,8 +712,7 @@ root element group, and any filter, clip-path, mask and and opacity is then
 applied, before compositing into the <a href="#rootgroup">root group</a>.
 
 <h3 id="rootgroup">The Root Group</h3>
-The root group is the final isolated group, and is is below the root
-element group.
+The root group encompasses the entire canvas and contains (or is below) the page group.
 
 <p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-4/#sample">white, 100% opaque</a> root group,
 for final compositing, but this is not required. For example, an iframe may

--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -712,10 +712,10 @@ root element group, and any filter, clip-path, mask and and opacity is then
 applied, before compositing into the <a href="#rootgroup">root group</a>.
 
 <h3 id="rootgroup">The Root Group</h3>
-The root group is the final compositing output, and is is below the root
+The root group is the final isolated group, and is is below the root
 element group.
 
-<p class="note">Browsers often use an infinite white, 100% opaque root group,
+<p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-3/#sample">white, 100% opaque</a> root group,
 for final compositing, but this is not required. For example, an iframe may
 have a transparent background, and therefore the root group contains content
 from an ancestor document.

--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -702,7 +702,7 @@ If the 'knock-out' property is disabled, each element within the group is only c
 -->
 <h3 id="pagebackdrop">The Page Group</h3>
 
-The <a href="#isolatedgroups">isolated group</a for the root element is the
+The <a href="#isolatedgroups">isolated group</a> for the root element is the
 page group. All other elements and groups are composited into this group.
 The background of the root element (if specified) is painted into the page
 group, and any filter, clip-path, mask and and opacity is then applied, before
@@ -710,8 +710,7 @@ compositing into the <a href="#rootgroup">root group</a>.
 
 <h3 id="rootgroup">The Root Group</h3>
 The root group is the final compositing output, and is is above the page
-group. Compositing of the page group into the root group is performed with the
-specified blend mode of the root element.
+group.
 
 <p class="note">Browsers often use an infinite white, 100% opaque root group,
 for final compositing, but this is not required. One example is an iframe with a transparent background.

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -722,7 +722,7 @@ applied, before compositing into the <a href="#rootgroup">root group</a>.
 The root group is the final isolated group, and is is below the root
 element group.
 
-<p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-3/#sample">white, 100% opaque</a> root group,
+<p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-4/#sample">white, 100% opaque</a> root group,
 for final compositing, but this is not required. For example, an iframe may
 have a transparent background, and therefore the root group contains content
 from an ancestor document.

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -89,6 +89,8 @@ Everything in CSS that creates a [=stacking context=] must be considered an <a h
 
 An element that has blending applied, must blend with all the underlying content of the [=stacking context=] that that element belongs to.
 
+The root element for an HTML document is the <a href="https://dom.spec.whatwg.org/#document-element">document element</a>.
+
 <h3 id="csscompositingrules_SVG">Behavior specific to SVG</h3>
 
 By default, every element must create a <a href="#isolatedgroups">non-isolated group</a>.
@@ -104,6 +106,8 @@ However, certain operations in SVG will create <a href="#isolatedgroups">isolate
 <li>blending</li>
 <li>masking</li>
 </ul>
+
+The root element for SVG is the <a href="https://www.w3.org/TR/SVG11/struct.html#NewDocument">SVG element</a>.
 
 <h3 id="csskeywords">CSS Properties</h3>
 
@@ -707,20 +711,21 @@ On the left, the group has the 'knock-out' property activated. On the right, the
 If the 'knock-out' property is disabled, each element within the group is only composited with the elements underneath the group.
 </p>
 -->
-<h3 id="pagebackdrop">The Page Group</h3>
+<h3 id="pagebackdrop">The Root Element Group</h3>
 
 The <a href="#isolatedgroups">isolated group</a> for the root element is the
-page group. All other elements and groups are composited into this group.
-The background of the root element (if specified) is painted into the page
-group, and any filter, clip-path, mask and and opacity is then applied, before
-compositing into the <a href="#rootgroup">root group</a>.
+root element group. All other elements and groups are composited into this group. The background of the root element (if specified) is painted into the
+root element group, and any filter, clip-path, mask and and opacity is then
+applied, before compositing into the <a href="#rootgroup">root group</a>.
 
 <h3 id="rootgroup">The Root Group</h3>
-The root group is the final compositing output, and is is above the page
-group.
+The root group is the final compositing output, and is is below the root
+element group.
 
 <p class="note">Browsers often use an infinite white, 100% opaque root group,
-for final compositing, but this is not required. One example is an iframe with a transparent background.
+for final compositing, but this is not required. For example, an iframe may
+have a transparent background, and therefore the root group contains content
+from an ancestor document.
 
 <h2 id="advancedcompositing">Advanced compositing features</h2>
 

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -716,15 +716,14 @@ If the 'knock-out' property is disabled, each element within the group is only c
 The <a href="#isolatedgroups">isolated group</a> for the root element is the
 root element group. All other elements and groups are composited into this group. The background of the root element (if specified) is painted into the
 root element group, and any filter, clip-path, mask and and opacity is then
-applied, before compositing into the <a href="#rootgroup">root group</a>.
+applied, before compositing into the <a href="#rootgroup">root group</a>,
+if present.
 
 <h3 id="rootgroup">The Root Group</h3>
-The root group encompasses the entire canvas and contains (or is below) the page group.
+The root group encompasses the entire canvas and contains (or is below) the root element group of the root element of a web page.
 
 <p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-4/#sample">white, 100% opaque</a> root group,
-for final compositing, but this is not required. For example, an iframe may
-have a transparent background, and therefore the root group contains content
-from an ancestor document.
+for final compositing, but this is not required.
 
 <h2 id="advancedcompositing">Advanced compositing features</h2>
 

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -719,10 +719,10 @@ root element group, and any filter, clip-path, mask and and opacity is then
 applied, before compositing into the <a href="#rootgroup">root group</a>.
 
 <h3 id="rootgroup">The Root Group</h3>
-The root group is the final compositing output, and is is below the root
+The root group is the final isolated group, and is is below the root
 element group.
 
-<p class="note">Browsers often use an infinite white, 100% opaque root group,
+<p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-3/#sample">white, 100% opaque</a> root group,
 for final compositing, but this is not required. For example, an iframe may
 have a transparent background, and therefore the root group contains content
 from an ancestor document.

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -709,7 +709,7 @@ If the 'knock-out' property is disabled, each element within the group is only c
 -->
 <h3 id="pagebackdrop">The Page Group</h3>
 
-The <a href="#isolatedgroups">isolated group</a for the root element is the
+The <a href="#isolatedgroups">isolated group</a> for the root element is the
 page group. All other elements and groups are composited into this group.
 The background of the root element (if specified) is painted into the page
 group, and any filter, clip-path, mask and and opacity is then applied, before
@@ -717,8 +717,7 @@ compositing into the <a href="#rootgroup">root group</a>.
 
 <h3 id="rootgroup">The Root Group</h3>
 The root group is the final compositing output, and is is above the page
-group. Compositing of the page group into the root group is performed with the
-specified blend mode of the root element.
+group.
 
 <p class="note">Browsers often use an infinite white, 100% opaque root group,
 for final compositing, but this is not required. One example is an iframe with a transparent background.

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -719,8 +719,7 @@ root element group, and any filter, clip-path, mask and and opacity is then
 applied, before compositing into the <a href="#rootgroup">root group</a>.
 
 <h3 id="rootgroup">The Root Group</h3>
-The root group is the final isolated group, and is is below the root
-element group.
+The root group encompasses the entire canvas and contains (or is below) the page group.
 
 <p class="note">Browsers often use an infinite <a href="https://www.w3.org/TR/css-color-4/#sample">white, 100% opaque</a> root group,
 for final compositing, but this is not required. For example, an iframe may


### PR DESCRIPTION
The background of the root element (if specified) should paint into the page group, and therefore any elements in the root stacking context/isolated group will blend with that color.