### PR TITLE
[motion-1] Corrected <ray()> and <path()> type syntax

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -103,7 +103,7 @@ Define a path: The 'offset-path' property {#offset-path-property}
 
 <pre class=propdef>
 Name: offset-path
-Value: none | ''ray()'' | <a href="#offsetpath-pathfunc">path()</a> | <<url>> | [ <<basic-shape>> && <<coord-box>>? ] | <<coord-box>>
+Value: none | <<ray()>> | <<offsetpath-pathfunc/path()>> | <<url>> | [ <<basic-shape>> && <<coord-box>>? ] | <<coord-box>>
 Initial: none
 Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Inherited: no
@@ -123,7 +123,7 @@ and the <dfn export for="offset path">initial direction</dfn>
 Values have the following meanings:
 
 <dl dfn-for=offset-path dfn-type=value>
-    : <dfn>ray()</dfn> = ray( [ <<angle>> && <<size>> && contain? ] )
+    : <dfn function>ray()</dfn> = ray( [ <<angle>> && <<size>> && contain? ] )
     ::
         : <<angle>>
         ::
@@ -195,7 +195,7 @@ Values have the following meanings:
     ::
         The <var>initial position</var> is the left end of the top horizontal line, immediately to the right of any 'border-radius' arc, and the <var>initial direction</var> is to the right.
 
-    : <dfn function id=offsetpath-pathfunc>path()</dfn> = path(<<string>>)
+    : <dfn for=offsetpath-pathfunc function>path()</dfn> = path( <<string>> )
     ::
         The <<string>> represents an SVG Path data string.
         The path data string must be conform to the grammar and parsing rules of SVG 1.1 [[!SVG11]].


### PR DESCRIPTION
This change corrects the syntax for the `<ray()>` and `<path()>` non-terminal component values as defined in point 4 of https://drafts.csswg.org/css-values-4/#component-types.

Fixes #410