### PR TITLE
[motion-1] Fixed link to <size> definition in ray() syntax

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -123,13 +123,13 @@ and the <dfn export for="offset path">initial direction</dfn>
 Values have the following meanings:
 
 <dl dfn-for=offset-path dfn-type=value>
-    : <dfn>ray()</dfn> = ray( [ <<angle>> && <<size>> && contain? ] )
+    : <dfn>ray()</dfn> = ray( [ <<angle>> && <a value for="ray()">&lt;size></a> && contain? ] )
     ::
-        : <<angle>>
+        : <dfn value for="ray()"><<angle>></dfn>
         ::
             The <a>offset path</a> is a line segment that starts from the position of the box and proceeds in the direction defined by the specified <<angle>>. As with <a href="https://www.w3.org/TR/css3-images/#gradients">CSS gradients</a>, <<angle>> values are interpreted as bearing angles, with ''0deg'' pointing up and positive angles representing clockwise rotation.
 
-        : <dfn for=offsetpath>&lt;size></dfn>
+        : <dfn value for="ray()">&lt;size></dfn>
         ::
             Decides the path length used when 'offset-distance' is expressed as a percentage, using the distance to the containing box. For <<size>> values other than <a href="#size-sides">sides</a>, the path length is independent of <<angle>>.
 
@@ -154,7 +154,7 @@ Values have the following meanings:
 
             Note: When <a href="#size-closest-side">closest-side</a> or <a href="#size-farthest-side">farthest-side</a> are used, and the initial position is outside the box, the sides are considered to extend indefinitely.
 
-        : <dfn>contain</dfn>
+        : <dfn value for="ray()">contain</dfn>
         ::
             The used value of 'offset-distance' is clamped so that the box is entirely contained within the path.
 


### PR DESCRIPTION
This fixes the linking to the definition of the `<size>` data type (see #411)