### PR TITLE
[motion-1] fix: unitless image height

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -322,7 +322,7 @@ For <a>shape element</a>s with associated CSS layout box, the <a>used value</a> 
     &lt;/body>
     </code></pre>
     <figure>
-        <img alt="An image of an increased path size" src="images/increase-size.svg" style="width: 400px; height: 335;"/>
+        <img alt="An image of an increased path size" src="images/increase-size.svg" width="400" height="335" />
         <figcaption>'offset-path' with path size increased</figcaption>
     </figure>
 


### PR DESCRIPTION
Convert to width/height attributes like others in document. Flagged by HTML validator