### PR TITLE
Column vectors are pre-multiplied by matrices.

### DIFF
--- a/geometry/Overview.bs
+++ b/geometry/Overview.bs
@@ -213,7 +213,7 @@ To <dfn export>transform a <a>point</a> with a <a>matrix</a></dfn>, given <var>p
     <var>y</var>, <var>z</var>, and <var>w</var>, respectively.
 
     <math display=inline><mrow><mfenced open=[ close=]><mrow><mtable><mtr><mtd><mi>x</mi></mtd></mtr><mtr><mtd><mi>y</mi></mtd></mtr><mtr><mtd><mi>z</mi></mtd></mtr><mtr><mtd><mi>w</mi></mtd></mtr></mtable></mrow></mfenced></mrow></math>
-6. Set <var>pointVector</var> to <var>pointVector</var> <a>post-multiplied</a> by
+6. Set <var>pointVector</var> to <var>pointVector</var> <a>pre-multiplied</a> by
     <var>matrix</var>.
 7. Let <var>transformedPoint</var> be a new {{DOMPoint}} object.
 8. Set <var>transformedPoint</var>'s <a for=point>x coordinate</a> to <var>pointVector</var>'s


### PR DESCRIPTION
Clarifies the behavior of e.g. matrix.transformPoint.
Resolves: #294, #359