### PR TITLE
[css-masking-1] Editorial fixes

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -9,17 +9,17 @@ TR: https://www.w3.org/TR/css-masking-1/
 Previous Version: https://www.w3.org/TR/2021/CRD-css-masking-1-20210805/
 Shortname: css-masking
 Level: 1
-Group: CSSWG
+Group: fxtf
 Editor: Dirk Schulze, Adobe Inc., dschulze@adobe.com, w3cid 51803
 Editor: Brian Birtles, Mozilla Japan, bbirtles@mozilla.com, w3cid 43194
-Editor: Tab Atkins Jr., Google, http://www.xanthir.com/contact/, w3cid 42199
+Editor: Tab Atkins Jr., Google, https://www.xanthir.com/contact/, w3cid 42199
 Abstract: CSS Masking provides two means for partially or fully hiding portions of visual elements: masking and clipping.
 Abstract:
 Abstract: Masking describes how to use another graphical element or image as a luminance or alpha mask. Typically, rendering an element via CSS or SVG can conceptually be described as if the element, including its children, are drawn into a buffer and then that buffer is composited into the element's parent. Luminance and alpha masks influence the transparency of this buffer before the compositing stage.
 Abstract:
 Abstract: Clipping describes the visible region of visual elements. The
  region can be described by using certain SVG graphics elements or basic shapes. Anything outside of this region is not rendered.
-Test Suite: http://test.csswg.org/suites/css-masking/nightly-unstable/
+Test Suite: https://test.csswg.org/suites/css-masking/nightly-unstable/
 Ignored Vars: trapeze.svg
 </pre>
 <pre class=link-defaults>
@@ -1435,7 +1435,7 @@ interface SVGMaskElement : SVGElement {
 
 <h2 class="no-num" id="changes">Changes since last publication</h2>
 
-The following changes were made since the <a href="http://www.w3.org/TR/2014/CR-css-masking-1-20140826/">26 August 2014 Candidate Recommendation</a>.
+The following changes were made since the <a href="https://www.w3.org/TR/2014/CR-css-masking-1-20140826/">26 August 2014 Candidate Recommendation</a>.
 * Allowed the <<'mask-mode'>> value in the 'mask' shorthand to appear anywhere other than between <<'mask-position'>> and <<'mask-size'>>.
 * Removed Implements SVGUnitTypes on clipPath and mask elements.
 * Apply properties that apply to all graphics elements to the use element as well.


### PR DESCRIPTION
* Change group from CSSWG to fxtf because the issue links are not correct (see https://www.w3.org/TR/2021/CRD-css-masking-1-20210805/#issue-d0c561ed for an example).
* http -> https