### PR TITLE
[fill-stroke-3] Replace "inline boxes" by "text" in Applies to

### DIFF
--- a/fill-stroke/Overview.bs
+++ b/fill-stroke/Overview.bs
@@ -261,7 +261,7 @@ Fill Paint {#fill-paint}
 		Name: fill-color
 		Value: <<color>>
 		Initial: currentcolor
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -306,7 +306,7 @@ Fill Paint {#fill-paint}
 		Name: fill-image
 		Value: <<paint>>#
 		Initial: none
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -396,7 +396,7 @@ Fill Paint {#fill-paint}
 		Name: fill-position
 		Value: <<position>>#
 		Initial: 0% 0%
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
 		Media: visual
@@ -417,7 +417,7 @@ Fill Paint {#fill-paint}
 		Name: fill-size
 		Value: <<bg-size>>#
 		Initial: auto
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
 		Media: visual
@@ -435,7 +435,7 @@ Fill Paint {#fill-paint}
 		Name: fill-repeat
 		Value: <<repeat-style>>#
 		Initial: repeat
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
 		Media: visual
@@ -497,7 +497,7 @@ Fill Transparency {#fill-filter}
 		Name: fill-opacity
 		Value: <<'opacity'>>
 		Initial: 1
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -577,7 +577,7 @@ Stroke Geometry {#stroke-geometry}
 		Name: stroke-width
 		Value: <<length-percentage>>#
 		Initial: 1px
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: relative to the <a>scaled viewport size</a>
 		Media: visual
@@ -597,7 +597,7 @@ Stroke Geometry {#stroke-geometry}
 		Name: stroke-align
 		Value: center | inset | outset
 		Initial: center
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -687,7 +687,7 @@ Stroke Geometry {#stroke-geometry}
 		Name: stroke-linecap
 		Value: butt | round | square
 		Initial: butt
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -748,7 +748,7 @@ Stroke Geometry {#stroke-geometry}
 		Name: stroke-linejoin
 		Value: [ crop | arcs | miter ] || [ bevel | round | fallback ]
 		Initial: miter
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -859,7 +859,7 @@ Stroke Geometry {#stroke-geometry}
 		Name: stroke-miterlimit
 		Value: <<number>>
 		Initial: 4
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -931,7 +931,7 @@ Stroke Dashing {#stroke-dashes}
 		Name: stroke-dasharray
 		Value: none | <<length-percentage>>+#
 		Initial: none
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: relative to the <a>scaled viewport size</a>
 		Media: visual
@@ -984,7 +984,7 @@ Stroke Dashing {#stroke-dashes}
 		Name: stroke-dashoffset
 		Value: <<length-percentage>>
 		Initial: 0
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: relative to the <a>scaled viewport size</a>
 		Media: visual
@@ -1012,7 +1012,7 @@ Stroke Dashing {#stroke-dashes}
 	Name: stroke-dash-corner
 	Value: none | <<length>>
 	Initial: none
-	Applies to: inline boxes and <a>SVG shapes</a>
+	Applies to: text and <a>SVG shapes</a>
 	Inherited: yes
 	Percentages: N/A
 	Media: visual
@@ -1080,7 +1080,7 @@ Stroke Dashing {#stroke-dashes}
 	Name: stroke-dash-justify
 	Value: none | [ stretch | compress ] || [ dashes || gaps ]
 	Initial: none
-	Applies to: inline boxes and <a>SVG shapes</a>
+	Applies to: text and <a>SVG shapes</a>
 	Inherited: yes
 	Percentages: N/A
 	Media: visual
@@ -1188,7 +1188,7 @@ Stroke Paint {#stroke-paint}
 		Name: stroke-color
 		Value: <<color>>#
 		Initial: transparent
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -1219,7 +1219,7 @@ Stroke Paint {#stroke-paint}
 		Name: stroke-image
 		Value: <<paint>>#
 		Initial: none
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual
@@ -1309,7 +1309,7 @@ Stroke Paint {#stroke-paint}
 		Name: stroke-position
 		Value: <<position>>#
 		Initial: 0% 0%
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
 		Media: visual
@@ -1330,7 +1330,7 @@ Stroke Paint {#stroke-paint}
 		Name: stroke-size
 		Value: <<bg-size>>#
 		Initial: auto
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
 		Media: visual
@@ -1348,7 +1348,7 @@ Stroke Paint {#stroke-paint}
 		Name: stroke-repeat
 		Value: <<repeat-style>>#
 		Initial: repeat
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
 		Media: visual
@@ -1394,7 +1394,7 @@ Stroke Paint {#stroke-paint}
 		Name: stroke-opacity
 		Value: <<'opacity'>>
 		Initial: 1
-		Applies to: inline boxes and <a>SVG shapes</a>
+		Applies to: text and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
 		Media: visual


### PR DESCRIPTION
This replaces "inline boxes" by "text" in the "Applies to" section of the property definition tables of Fill and Stroke 3 as of the resolution in https://github.com/w3c/csswg-drafts/issues/5303.

It fixes https://github.com/w3c/csswg-drafts/issues/6823.

Sebastian