### PR TITLE
[compositing-2] Fixed examples with percentages in rgb() functions

### DIFF
--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -1034,10 +1034,10 @@ With the <dfn>plus-lighter</dfn> compositing operator, the following steps are p
       grid-area: 1 / 1;
     }
     .from {
-      background-color: rgb(100% 0 0 / 50%);
+      background-color: rgb(100% 0% 0% / 50%);
     }
     .to {
-      background-color: rgb(0 0 100% / 50%);
+      background-color: rgb(0% 0% 100% / 50%);
     }
   </pre>
 
@@ -1052,7 +1052,7 @@ With the <dfn>plus-lighter</dfn> compositing operator, the following steps are p
     }
   </pre>
 
-  <p>However, with default <a>source-over</a> compositing, this produces a result of roughly <code>rgb(43% 0 57% / 44%)</code>. This is correct value when "layering" elements, but it's incorrect for a 50% cross-fade.</p>
+  <p>However, with default <a>source-over</a> compositing, this produces a result of roughly <code>rgb(43% 0% 57% / 44%)</code>. This is correct value when "layering" elements, but it's incorrect for a 50% cross-fade.</p>
 
   <p>Instead, using <a>plus-lighter</a>:</p>
 
@@ -1070,7 +1070,7 @@ With the <dfn>plus-lighter</dfn> compositing operator, the following steps are p
     }
   </pre>
 
-  <p>This results in <code>rgb(50% 0 50% / 50%)</code>, which is correctly "half-way" between the <code>from</code> and <code>to</code> colors.</p>
+  <p>This results in <code>rgb(50% 0% 50% / 50%)</code>, which is correctly "half-way" between the <code>from</code> and <code>to</code> colors.</p>
   </div>
 
 <h3 id="groupcompositing">Group compositing behavior with Porter Duff modes</h3>


### PR DESCRIPTION
The syntax for `rgb()` only allows _either_ all color components to be `<number>`s or `<percentage>` but not mix them. That means that `0` values must be written as `0%`.

This change fixes all occurrences of those erroneous uses of `rgb()` and by that fixes #456.

Sebastian