### PR TITLE
[css-masking-1] Fix <'clip'> syntax

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -1288,7 +1288,7 @@ While CSS capabilities like those defined in this module can be used to hide con
 
 <pre class=propdef>
 Name: clip
-Value: ''clip/rect()'' | ''clip/auto''
+Value: <<clip/rect()>> | ''clip/auto''
 Initial: auto
 Applies to: Absolutely positioned elements. In SVG, it applies to <a href="https://www.w3.org/TR/SVG/coords.html#EstablishingANewSVGViewport">elements which establish a new viewport</a>, <a element>pattern</a> elements and <a element>mask</a> elements.
 Inherited: no


### PR DESCRIPTION
`rect()` should be a `<reference>` to a production definition