### PR TITLE
[css-masking-1] Fix overlapping <rect()>

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -1288,7 +1288,7 @@ While CSS capabilities like those defined in this module can be used to hide con
 
 <pre class=propdef>
 Name: clip
-Value: <<clip/rect()>> | ''clip/auto''
+Value: <a function for="clip" lt="rect()">rect( &lt;top>, &lt;right>, &lt;bottom>, &lt;left> )</a> | ''clip/auto''
 Initial: auto
 Applies to: Absolutely positioned elements. In SVG, it applies to <a href="https://www.w3.org/TR/SVG/coords.html#EstablishingANewSVGViewport">elements which establish a new viewport</a>, <a element>pattern</a> elements and <a element>mask</a> elements.
 Inherited: no


### PR DESCRIPTION
The `<rect()>` definition for `clip` is overlapping with the newer `<rect()>` definition in CSS Basic Shapes. This change inlines the definition for `clip` instead of using a production type.

Fixes https://github.com/w3c/csswg-drafts/issues/7219