### PR TITLE
[css-masking-1] No more <number-percentage> #7727

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -1015,7 +1015,7 @@ The 'mask-mode' and 'mask-type' properties must have no affect on the <a>mask bo
 
 <pre class=propdef>
 Name: mask-border-slice
-Value: <<number-percentage>>{1,4} fill?
+Value: [ <<number>> | <<percentage>> ]{1,4} fill?
 Initial: 0
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no


### PR DESCRIPTION
I think this is the last remaining occurrence of `<number-percentage>`.

Follow-up on: https://github.com/w3c/fxtf-drafts/commit/fe40e6efc92d644983f538cc72995cf73535ca8c
Related: https://github.com/w3c/csswg-drafts/issues/7727