### PR TITLE
[motion-1] Make <ray-size> optional. Defaulting to 'closest-side'.

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -207,7 +207,7 @@ The ''ray()'' function defines an [=offset path=]
 as a straight line emerging from a point at some defined angle:
 
 <pre class=prod>
-<dfn>ray()</dfn> = ray( <<angle>> && <<ray-size>> && contain? )
+<dfn>ray()</dfn> = ray( <<angle>> && <<ray-size>>? && contain? )
 
 <dfn>&lt;ray-size></dfn> = closest-side | closest-corner | farthest-side | farthest-corner | sides
 </pre>
@@ -233,6 +233,8 @@ Its arguments are:
         (the distance between the ''offset-distance: 0%''
         and ''offset-distance: 100%'' points)
         relative to the [=containing box=].
+
+        If no <<ray-size>> is specified it defaults to ''closest-side''.
 
         Note: For ''sides'',
         the distance depends on the <<angle>> specified;


### PR DESCRIPTION
Makes <ray-size> optional, defaulting to 'closest-side'.
It's done for the cases when 'offset-distance' is specified in pixels.

Fixes https://github.com/w3c/fxtf-drafts/issues/491