### PR TITLE
[motion-1] Move path() to the <basic-shape> section.

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -111,7 +111,7 @@ Defining A Path: The 'offset-path' property {#offset-path-property}
 
 <pre class=propdef>
 Name: offset-path
-Value: none | <<ray()>> | <<offsetpath-pathfunc/path()>> | <<url>> | [ <<basic-shape>> && <<coord-box>>? ] | <<coord-box>>
+Value: none | <<ray()>> | <<url>> | [ <<basic-shape>> && <<coord-box>>? ] | <<coord-box>>
 Initial: none
 Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Inherited: no
@@ -145,6 +145,9 @@ Values have the following meanings:
 
         The <var>initial position</var> for basic shapes are defined as follows:
 
+        : <<path()>>
+        ::
+            The <var>initial position</var> is defined by the first “move to” argument in the path string. For the initial direction follow SVG 1.1 [[!SVG11]].
         : <<circle()>>
         : <<ellipse()>>
         ::
@@ -174,12 +177,6 @@ Values have the following meanings:
         The <var>initial position</var> is the left end of the top horizontal line,
         immediately to the right of any 'border-radius' arc,
         and the <var>initial direction</var> is to the right.
-
-    : <dfn for=offsetpath-pathfunc function>path()</dfn> = path( <<string>> )
-    ::
-        The <<string>> represents an SVG Path data string.
-        The path data string must be conform to the grammar and parsing rules of SVG 1.1 [[!SVG11]].
-        The <var>initial position</var> is defined by the first “move to” argument in the path string. For the <var>initial direction</var> follow SVG 1.1 [[!SVG11]].
 
     : <<url>>
     ::


### PR DESCRIPTION
Moves path function to the basic-shape section as it's now one of the basic shapes.

Fixes https://github.com/w3c/fxtf-drafts/issues/493