### PR TITLE
[css-compositing][css-masking] Force rendering whitespaces around combinators

### DIFF
--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -123,9 +123,15 @@ Animatable: no
 
 The syntax of the property of <<blend-mode>> is given with:
 
-<pre class="blendmode prod"><dfn id="ltblendmodegt">&lt;blend-mode></dfn> = <a value>normal</a> | <a value>multiply</a> | <a value>screen</a> | <a value>overlay</a> | <a value>darken</a> | <a value>lighten</a> | <a value>color-dodge</a> |
-  <a value>color-burn</a> | <a value>hard-light</a> | <a value>soft-light</a> | <a value>difference</a> | <a value>exclusion</a> | <a value>hue</a> |
-  <a value>saturation</a> | <a value>color</a> | <a value>luminosity</a></pre>
+<pre class="blendmode prod">
+  <dfn id="ltblendmodegt">&lt;blend-mode></dfn> =
+    <a value>normal</a> |
+    <a value>darken</a> | <a value>multiply</a> | <a value>color-burn</a> |
+    <a value>lighten</a> | <a value>screen</a> | <a value>color-dodge</a> |
+    <a value>overlay</a> | <a value>soft-light</a> | <a value>hard-light</a> |
+    <a value>difference</a> | <a value>exclusion</a> |
+    <a value>hue</a> | <a value>saturation</a> | <a value>color</a> | <a value>luminosity</a>
+</pre>
 
 Note: Applying a blendmode other than <a value>normal</a> to the element must establish a new <a spec="css21">stacking context</a> [[!CSS21]]. This group must then be blended and composited with the <a spec="css21">stacking context</a> that contains the element.
 

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -130,9 +130,15 @@ Animatable: no
 
 The syntax of the property of <<blend-mode>> is given with:
 
-<pre class="blendmode prod"><dfn id="ltblendmodegt">&lt;blend-mode></dfn> = <a value>normal</a> | <a value>multiply</a> | <a value>screen</a> | <a value>overlay</a> | <a value>darken</a> | <a value>lighten</a> | <a value>color-dodge</a> |
-  <a value>color-burn</a> | <a value>hard-light</a> | <a value>soft-light</a> | <a value>difference</a> | <a value>exclusion</a> | <a value>hue</a> |
-  <a value>saturation</a> | <a value>color</a> | <a value>luminosity</a></pre>
+<pre class="blendmode prod">
+  <dfn id="ltblendmodegt">&lt;blend-mode></dfn> =
+    <a value>normal</a> |
+    <a value>darken</a> | <a value>multiply</a> | <a value>color-burn</a> |
+    <a value>lighten</a> | <a value>screen</a> | <a value>color-dodge</a> |
+    <a value>overlay</a> | <a value>soft-light</a> | <a value>hard-light</a> |
+    <a value>difference</a> | <a value>exclusion</a> |
+    <a value>hue</a> | <a value>saturation</a> | <a value>color</a> | <a value>luminosity</a>
+</pre>
 
 Note: Applying a blendmode other than <a value>normal</a> to the element must establish a new [=stacking context=]. This group must then be blended and composited with the [=stacking context=] that contains the element.
 

--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -860,8 +860,16 @@ Media: visual
 Animation type: see individual properties
 </pre>
 
-<pre class=prod><dfn>&lt;mask-layer></dfn> = <<mask-reference>> || <<position>> [ / <<bg-size>> ]? ||
-    <<repeat-style>> || <<geometry-box>> || [ <<geometry-box>> | no-clip ] || <<compositing-operator>> || <<masking-mode>></pre>
+<pre class=prod>
+  <dfn>&lt;mask-layer></dfn> =
+    <<mask-reference>> ||
+    <<position>> [ / <<bg-size>> ]? ||
+    <<repeat-style>> ||
+    <<geometry-box>> ||
+    [ <<geometry-box>> | no-clip ] ||
+    <<compositing-operator>> ||
+    <<masking-mode>>
+</pre>
 
 If one <<geometry-box>> value and the ''no-clip'' keyword are present then <<geometry-box>> sets 'mask-origin' and ''no-clip'' sets 'mask-clip' to that value.
 


### PR DESCRIPTION
The basic syntax definition of `<blend-mode>` and `<mask-layer>` is rendered in browsers without a whitespace where the first line break of a `<pre>` appears in the Bikeshed source text:

```
<blend-mode> = ... |color-burn | ...
<mask-layer> = ... ||<repeat-style> || ...
```

I do not know why Bikeshed removes the line break therefore I am not sure this PR is appropriate.

---

`<blend-mode>` values have been grouped as in popular graphic design softwares.

---

**Aside**

I do not know if the missing whitespace is a syntax error, or if a css value definition parser should handle it.

`initial-value` (in `@property`) may support combinations in the future and authors may use line breaks in combinations.

The CSS value definition syntax may have to define if 1. one or more whitespaces and/or line breaks should always appear between symbols in combinations, or if 2. they can be omitted in some cases.

```
@property --custom {
  initial-value: "<foo><bar>"; /* valid? */
  initial-value: "foo\
    bar";                      /* valid? */
}
```