### PR TITLE
[css-masking-1] Allow permutation in mask-border-slice

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -1023,7 +1023,7 @@ The 'mask-mode' and 'mask-type' properties must have no affect on the <a>mask bo
 
 <pre class=propdef>
 Name: mask-border-slice
-Value: [ <<number>> | <<percentage>> ]{1,4} fill?
+Value: [ <<number>> | <<percentage>> ]{1,4} && fill?
 Initial: 0
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no


### PR DESCRIPTION
I think `&&` was lost in [this commit](https://github.com/w3c/fxtf-drafts/commit/7af5acb2b6d290a3fa9508cf76af05b772057b23#diff-aacf1a334bd4ec16c705bf164f6bc873cbaee4b25944da51f00184c321b84562L1167-L1171). 

  > **Name:** `mask-border-slice`
  > **Value:** `[ <number> | <percentage> ]{1,4} fill?`
  >
  > See the `border-image-slice` property [CSS3BG] for the definitions of the property values.

https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice

  > **Name:** `border-image-slice`
  > **Value:** `[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?`

https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice

---

The following longhand pairs also have different initial values, different animation types, and numeric CSS types are constrained for one but not the other:

  - [`border-image-slice`](https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice) and [`mask-border-slice`](https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice)
  - [`border-image-width`](https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width) and [`mask-border-width`](https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width)
  - [`border-image-outset`](https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-outset) and [`mask-border-outset`](https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset)

I am not sure (all) these differences are intentional.