### PR TITLE
Convert `Animatable` to `Animation type` prop definition field

### DIFF
--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -125,7 +125,7 @@ Inherited: no
 Percentages: N/A
 Computed value: as specified
 Media: visual
-Animatable: no
+Animation type: discrete
 </pre>
 
 The syntax of the property of <<blend-mode>> is given with:
@@ -274,7 +274,7 @@ Inherited: no
 Percentages: N/A
 Computed value: as specified
 Media: visual
-Animatable: no
+Animation type: discrete
 </pre>
 
 The syntax of the property of <<isolation-mode>> is given with:
@@ -303,7 +303,7 @@ Inherited: no
 Percentages: N/A
 Computed value: as specified
 Media: visual
-Animatable: no
+Animation type: discrete
 </pre>
 
 The 'background-blend-mode' list must be applied in the same order as 'background-image' [[!CSS3BG]]. This means that the first element in the list will apply to the layer that is on top. If a property doesn't have enough comma-separated values to match the number of layers, the UA must calculate its used value by repeating the list of values until there are enough.</p>

--- a/fill-stroke/Overview.bs
+++ b/fill-stroke/Overview.bs
@@ -171,7 +171,7 @@ Fill Geometry {#fill-geometry}
 		Percentages: N/A
 		Media: visual
 		Computed Value: as specified
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	The 'fill-rule' property indicates the rule
@@ -245,7 +245,7 @@ Fill Geometry {#fill-geometry}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified
-		Animatable: No
+		Animation type: discrete
 	</pre>
 
 	This property specifies how the geometry of a <a>fragmented</a> box is treated for <a>fills</a>.
@@ -266,7 +266,7 @@ Fill Paint {#fill-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: the computed color
-		Animatable: as color
+		Animation type: by computed value
 	</pre>
 
 	This property sets the fill color of an element.
@@ -311,7 +311,7 @@ Fill Paint {#fill-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified, with any <<image>> computed
-		Animatable: as repeatable list of images
+		Animation type: repeatable list
 	</pre>
 
 	This property sets the fill images of an element.
@@ -331,7 +331,7 @@ Fill Paint {#fill-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	This property specifies the coordinate system of the <a>fill</a>,
@@ -401,7 +401,7 @@ Fill Paint {#fill-paint}
 		Percentages: n/a
 		Media: visual
 		Computed value: A list, each item consisting of: a pair of offsets (horizontal and vertical) from the top left origin each given as a combination of an absolute length and a percentage
-		Animatable: as <a>repeatable list</a> of <a>simple list</a> of length, percentage, or calc
+		Animation type: repeatable list
 	</pre>
 
 	If fill images have been specified,
@@ -422,7 +422,7 @@ Fill Paint {#fill-paint}
 		Percentages: n/a
 		Media: visual
 		Computed value: as specified, but with lengths made absolute and omitted ''background-size/auto'' keywords filled in
-		Animatable: as <a>repeatable list</a> of <a>simple list</a> of length, percentage, or calc
+		Animation type: repeatable list
 	</pre>
 
 	Specifies the size of the fill images.
@@ -440,7 +440,7 @@ Fill Paint {#fill-paint}
 		Percentages: n/a
 		Media: visual
 		Computed value: A list, each item consisting of: two keywords, one per dimension
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	Specifies how fill images are tiled after they have been sized and positioned.
@@ -458,7 +458,7 @@ Fill Paint {#fill-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: See individual properties
-		Animatable: See individual properties
+		Animation type: See individual properties
 	</pre>
 
 	This property is a <a>shorthand</a> that sets all of the fill painting properties--
@@ -502,7 +502,7 @@ Fill Transparency {#fill-filter}
 		Percentages: N/A
 		Media: visual
 		Computed value: the specified value converted to a <<number>>, clamped to the range [0,1]
-		Animatable: as number
+		Animation type: by computed value
 	</pre>
 
 	The 'fill-opacity' property specifies the opacity of the painting operation
@@ -582,7 +582,7 @@ Stroke Geometry {#stroke-geometry}
 		Percentages: relative to the <a>scaled viewport size</a>
 		Media: visual
 		Computed value: the absolute length, or percentage
-		Animatable: as <<length-percentage>>
+		Animation type: by computed value
 	</pre>
 
 	This property specifies the width of the strokes on the outline.
@@ -602,7 +602,7 @@ Stroke Geometry {#stroke-geometry}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	This property allows the author to align a <a>stroke</a> along the outline.
@@ -692,7 +692,7 @@ Stroke Geometry {#stroke-geometry}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	'stroke-linecap' specifies the shape to be used at the end of open subpaths
@@ -753,7 +753,7 @@ Stroke Geometry {#stroke-geometry}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	'stroke-linejoin' specifies the shape to be used at the corners of paths or basic shapes when they are stroked.
@@ -864,7 +864,7 @@ Stroke Geometry {#stroke-geometry}
 		Percentages: N/A
 		Media: visual
 		Computed value: a number
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	This property specifies the maximum size of a ''miter'' or ''arcs'' join
@@ -915,7 +915,7 @@ Stroke Geometry {#stroke-geometry}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified
-		Animatable: No
+		Animation type: discrete
 	</pre>
 
 	This property specifies how the geometry of a <a>fragmented</a> box is treated for <a>strokes</a>.
@@ -936,7 +936,7 @@ Stroke Dashing {#stroke-dashes}
 		Percentages: relative to the <a>scaled viewport size</a>
 		Media: visual
 		Computed value: as specified
-		Animatable: as repeated list of length, percentage or calc
+		Animation type: repeatable list
 	</pre>
 
 	This property controls the pattern of dashes and gaps used to stroke paths.
@@ -989,7 +989,7 @@ Stroke Dashing {#stroke-dashes}
 		Percentages: relative to the <a>scaled viewport size</a>
 		Media: visual
 		Computed value: as specified
-		Animatable: as repeated list of integers
+		Animation type: repeatable list
 	</pre>
 
 	This property specifies the distance into the repeated dash pattern to start dashing at the beginning of the path.
@@ -1017,7 +1017,7 @@ Stroke Dashing {#stroke-dashes}
 	Percentages: N/A
 	Media: visual
 	Computed Value: specified value, with lengths made absolute
-	Animatable: yes, if <<length>>
+	Animation type: by computed value if <<length>>, otherwise discrete
 	</pre>
 
 	The 'stroke-dash-corner' property controls
@@ -1085,7 +1085,7 @@ Stroke Dashing {#stroke-dashes}
 	Percentages: N/A
 	Media: visual
 	Computed Value: specified value, with lengths made absolute
-	Animatable: no
+	Animation type: discrete
 	</pre>
 
 	The 'stroke-dash-justify' property specifies
@@ -1193,7 +1193,7 @@ Stroke Paint {#stroke-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: the computed color
-		Animatable: as color
+		Animation type: by computed value
 	</pre>
 
 	This property sets the stroke colors of an element.
@@ -1224,7 +1224,7 @@ Stroke Paint {#stroke-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified, with any <<image>> computed
-		Animatable: as repeatable list of images
+		Animation type: repeatable list
 	</pre>
 
 	This property sets the stroke images of an element.
@@ -1244,7 +1244,7 @@ Stroke Paint {#stroke-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: as specified
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	This property specifies the coordinate system of the <a>stroke</a>,
@@ -1314,7 +1314,7 @@ Stroke Paint {#stroke-paint}
 		Percentages: n/a
 		Media: visual
 		Computed value: A list, each item consisting of: a pair of offsets (horizontal and vertical) from the top left origin each given as a combination of an absolute length and a percentage
-		Animatable: as <a>repeatable list</a> of <a>simple list</a> of length, percentage, or calc
+		Animation type: repeatable list
 	</pre>
 
 	If stroke images have been specified,
@@ -1335,7 +1335,7 @@ Stroke Paint {#stroke-paint}
 		Percentages: n/a
 		Media: visual
 		Computed value: as specified, but with lengths made absolute and omitted ''background-size/auto'' keywords filled in
-		Animatable: as <a>repeatable list</a> of <a>simple list</a> of length, percentage, or calc
+		Animation type: repeatable list
 	</pre>
 
 	Specifies the size of the stroke images.
@@ -1353,7 +1353,7 @@ Stroke Paint {#stroke-paint}
 		Percentages: n/a
 		Media: visual
 		Computed value: A list, each item consisting of: two keywords, one per dimension
-		Animatable: no
+		Animation type: discrete
 	</pre>
 
 	Specifies how stroke fill images are tiled after they have been sized and positioned.
@@ -1371,7 +1371,7 @@ Stroke Paint {#stroke-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: See individual properties
-		Animatable: See individual properties
+		Animation type: See individual properties
 	</pre>
 
 	This property is a <a>shorthand</a> that sets all of the stroke painting properties--
@@ -1399,7 +1399,7 @@ Stroke Paint {#stroke-paint}
 		Percentages: N/A
 		Media: visual
 		Computed value: the specified value converted to a <<number>>, clamped to the range [0,1]
-		Animatable: as number
+		Animation type: by computed value
 	</pre>
 
 	The 'stroke-opacity' property specifies the opacity of the painting operation

--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -47,7 +47,7 @@ Inherited: no
 Percentages: n/a
 Computed value: as specified
 Media: visual
-Animatable: yes
+Animation type: see prose in [[filter-effects#animation-of-filters]].
 </pre>
 
 If the value of the 'backdrop-filter' property is ''backdrop-filter/none'' then there is no


### PR DESCRIPTION
- fixes #521
- replaces all occurrences of `Animatable` with `Animation type` as a property definition field
- replaces `no` with `not animatable` (as an `Animation type` value)
  - `isolation` ***edit***: replaced with `discrete` (see following comment and https://github.com/w3c/fxtf-drafts/commit/402eece3e43edb5f52ac9a6c21f6e62bf2ed913d)
- replaces `no` with `discrete`
  - `background-blend-mode`, `mix-blend-mode`
  - `fill-break`, `stroke-break`
  - `fill-origin`, `stroke-origin`
  - `fill-repeat`, `stroke-repeat`
  - `fill-rule`
  - `stroke-align`
  - `stroke-dash-justify`
  - `stroke-linecap`
  - `stroke-linejoin`
  - `stroke-miterlimit`
- replaces `as repeatable list of integers` with `by computed value`
  - `stroke-dashoffset`
- replaces `as repeatable list of *` with `as repeatable list`
  - `fill-image`, `stroke-image`
  - `fill-position`, `stroke-position`
  - `fill-size`, `stroke-size`
  - `stroke-dasharray`
- replaces `as color` with `by computed value`
  - `fill-color`, `stroke-color`
- replaces `as <length-percentage>` with `by computed value`
  - `stroke-width`
- replaces `as number` with `by computed value`
  - `fill-opacity`, `stroke-opacity`
- replaces `yes, if <length>` with `by computed value if <length>, otherwise discrete`
  - `stroke-dash-corner`
- replaces `yes` with `See prose in Animation of Filters`
  - `backdrop-filter`