### PR TITLE
[motion-1][editorial] Use <radial-extent> as reference for ray size keywords

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -242,7 +242,7 @@ as a straight line emerging from a point at some defined angle:
 <pre class=prod>
 <dfn>ray()</dfn> = ray( <<angle>> && <<ray-size>>? && contain? && [at <<position>>]? )
 
-<dfn>&lt;ray-size></dfn> = closest-side | closest-corner | farthest-side | farthest-corner | sides
+<dfn>&lt;ray-size></dfn> = <<radial-extent>> | sides
 </pre>
 
 Its arguments are:


### PR DESCRIPTION
I am not sure you want to allow [`<radial-extent>`](https://drafts.csswg.org/css-images-3/#typedef-radial-extent) to be used in `<ray-size>` when the name of the former suggests it is meant to be used only in `<radial-size>`.