### PR TITLE
[filter-effects-1] Replace `<alpha-value>` with `<'opacity'>`

### DIFF
--- a/filter-effects/Overview.bs
+++ b/filter-effects/Overview.bs
@@ -2250,7 +2250,7 @@ The 'flood-color' property is a <a href="https://www.w3.org/TR/2011/REC-SVG11-20
 
 <pre class='propdef'>
 Name: flood-opacity
-Value: <<alpha-value>>
+Value: <<'opacity'>>
 Initial: 1
 Applies to: <a element>feFlood</a> and <a element>feDropShadow</a> elements
 Inherited: no


### PR DESCRIPTION
[`flood-opacity`](https://drafts.fxtf.org/filter-effects-1/#FloodOpacityProperty) is defined with `<alpha-value>` but its specified value must be clamped whereas there is interop for clamping the computed value, like for `opacity`.

I suggest to define `flood-opacity` with `<'opacity'>`.

Related: https://github.com/w3c/csswg-drafts/issues/8311