### PR TITLE
[css-masking-1] Replace <geometry-box> with <coord-box> for mask shorthand property.

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -865,17 +865,17 @@ Animation type: see individual properties
     <<mask-reference>> ||
     <<position>> [ / <<bg-size>> ]? ||
     <<repeat-style>> ||
-    <<geometry-box>> ||
-    [ <<geometry-box>> | no-clip ] ||
+    <<coord-box>> ||
+    [ <<coord-box>> | no-clip ] ||
     <<compositing-operator>> ||
     <<masking-mode>>
 </pre>
 
-If one <<geometry-box>> value and the ''no-clip'' keyword are present then <<geometry-box>> sets 'mask-origin' and ''no-clip'' sets 'mask-clip' to that value.
+If one <<coord-box>> value and the ''no-clip'' keyword are present then <<coord-box>> sets 'mask-origin' and ''no-clip'' sets 'mask-clip' to that value.
 
-If one <<geometry-box>> value and no ''no-clip'' keyword are present then <<geometry-box>> sets both 'mask-origin' and 'mask-clip' to that value.
+If one <<coord-box>> value and no ''no-clip'' keyword are present then <<coord-box>> sets both 'mask-origin' and 'mask-clip' to that value.
 
-If two <<geometry-box>> values are present, then the first sets 'mask-origin' and the second 'mask-clip'.
+If two <<coord-box>> values are present, then the first sets 'mask-origin' and the second 'mask-clip'.
 
 The <a>used value</a> of the properties 'mask-repeat', 'mask-position', 'mask-clip', 'mask-origin' and 'mask-size' must have no effect if <<mask-reference>> references a <a element>mask</a> element. In this case the element defines position, sizing and clipping of the <a>mask layer image</a>.
 


### PR DESCRIPTION
`mask-origin` and `mask-clip` use `<coord-box>`, and for consistency, the syntax and description of `mask` shorthand should use `<coord-box>` for these two components.

Issue: #551