### PR TITLE
[filter-effects] Add mirror edgeMode filter

### DIFF
--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -80,7 +80,7 @@ output as its SourceGraphic.
 Filter functions must operate in the sRGB color space.
 
 If the filter functions list includes a <a href="https://drafts.fxtf.org/filter-effects-1/#blurEquivalent">blur()</a>
-filter, the filter will be applied with edgeMode="duplicate", with the edge defined by the clipped, transformed border
+filter, the filter will be applied with edgeMode="mirror", with the edge defined by the clipped, transformed border
 box of the element. See [[#BackdropRoot]].
 
 Note: The effect of the backdrop-filter will not be visible unless some

--- a/filter-effects/Overview.bs
+++ b/filter-effects/Overview.bs
@@ -1674,7 +1674,7 @@ When the image must be resampled to match the coordinate system defined by <a el
         Determines the positioning in Y of the convolution matrix relative to a given target pixel in the input image. The topmost row of the matrix is row number zero. The value must be such that: 0 &lt;= targetY &lt; orderY. By default, the convolution matrix is centered in Y over each pixel of the input image (i.e., targetY = floor ( orderY / 2 )).</p>
 
         Animatable: yes.
-    : <dfn>edgeMode</dfn> = "<a attr-value>duplicate</a> | <a attr-value>wrap</a> | none</span>"
+    : <dfn>edgeMode</dfn> = "<a attr-value>duplicate</a> | <a attr-value>wrap</a> | <a attr-value>mirror</a> | none</span>"
     ::
         Determines how to extend the input image as necessary with color values so that the matrix operations can be applied when the kernel is positioned at or near the edge of the input image.
 
@@ -1693,6 +1693,12 @@ When the image must be resampled to match the coordinate system defined by <a el
         Extended by two pixels using <a attr-value>wrap</a>:
 
         <pre class=include>path: mathml/feConvolveMatrix06.mml</pre>
+
+        <a attr-value>mirror</a> indicates that the input image is extended by taking color values mirrored across the edge being sampled beyond.
+
+        Extended by two pixels using <a attr-value>mirror</a>:
+
+        <pre class=include>path: mathml/feConvolveMatrix07.mml</pre>
 
         The value ''feConvolveMatrix/none'' indicates that the input image is extended with pixel values of zero for R, G, B and A.
 
@@ -2331,7 +2337,7 @@ Frequently this operation will take place on alpha-only images, such as that pro
         The <a for=svg>initial value</a> for <a element-attr for=feGaussianBlur>stdDeviation</a> is ''0''.
 
         Animatable: yes.
-    : <dfn>edgeMode</dfn> = "<a attr-value>duplicate</a> | <a attr-value>wrap</a> | none"
+    : <dfn>edgeMode</dfn> = "<a attr-value>duplicate</a> | <a attr-value>wrap</a> | <a attr-value>mirror</a> | none"
     ::
         Determines how to extend the input image as necessary with color values so that the matrix operations can be applied when the kernel is positioned at or near the edge of the input image.
 
@@ -2340,6 +2346,8 @@ Frequently this operation will take place on alpha-only images, such as that pro
         Original N-by-M image, where m=M-1 and n=N-1:
 
         <dfn dfn-type=attr-value dfn-for=feGaussianBlur/edgeMode>wrap</dfn> indicates that the input image is extended by taking the color values from the opposite edge of the image.
+
+        <dfn dfn-type=attr-value dfn-for=feGuassianBlur/edgeMode>mirror</dfn> indicates that the input image is extended by taking color values mirrored across the edge being sampled beyond.
 
         The value ''feGaussianBlur/none'' indicates that the input image is extended with pixel values of zero for R, G, B and A.
 

--- a/filter-effects/mathml/feConvolveMatrix07.mml
+++ b/filter-effects/mathml/feConvolveMatrix07.mml
@@ -1,0 +1,448 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<math xmlns="http://www.w3.org/1998/Math/MathML">
+ <semantics>
+  <mrow>
+   <mfenced open="[" close="]">
+    <mrow>
+     <mtable>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">22</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">21</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">21</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">22</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">2m</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">2M</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">2M</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">2m</mi>
+        </mrow>
+       </mtd>
+      </mtr>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">12</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">11</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">11</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">12</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">1m</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">1M</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">1M</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">1m</mi>
+        </mrow>
+       </mtd>
+      </mtr>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mn>12</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>11</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>11</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>12</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>1m</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>1M</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>1M</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>1m</mn>
+        </mrow>
+       </mtd>
+      </mtr>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mn>22</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>21</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>21</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>22</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>2m</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>2M</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>2M</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>2m</mn>
+        </mrow>
+       </mtd>
+      </mtr>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+      </mtr>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">n2</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">n1</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">n1</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">n2</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">nm</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">nM</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">nM</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">nm</mi>
+        </mrow>
+       </mtd>
+      </mtr>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">N2</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">N1</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">N1</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">N2</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">Nm</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">NM</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">NM</mi>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mi mathvariant="italic">Nm</mi>
+        </mrow>
+       </mtd>
+      </mtr>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mn>N2</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>N1</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>N1</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>N2</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>Nm</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>NM</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>NM</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>Nm</mn>
+        </mrow>
+       </mtd>
+      </mtr>
+      <mtr>
+       <mtd>
+        <mrow>
+         <mn>n2</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>n1</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>n1</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>n2</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mo stretchy="false">…</mo>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>nm</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>nM</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>nM</mn>
+        </mrow>
+       </mtd>
+       <mtd>
+        <mrow>
+         <mn>nm</mn>
+        </mrow>
+       </mtd>
+      </mtr>
+     </mtable>
+    </mrow>
+   </mfenced>
+  </mrow>
+  <annotation encoding="StarMath 5.0">left[ matrix {
+22 # 21 # 21 # 22 # dotslow # 2m # 2M # 2M # 2m ##
+12 # 11 # 11 # 12 # dotslow # 1m # 1M # 1M # 1m ##
+11 # 11 # 11 # 12 # dotslow # 1m # 1M # 1M # 1m ##
+22 # 21 # 21 # 22 # dotslow # 2m # 2M # 2M # 2m ##
+dotslow # dotslow # dotslow # dotslow # dotslow # dotslow # dotslow # dotslow # dotslow ##
+n2 # n1 # n1 # n2 # dotslow # nm # nM # nM # nm ##
+N2 # N1 # N1 # N2 # dotslow # Nm # NM # NM # Nm ##
+N2 # N1 # N1 # N2 # dotslow # Nm # NM # NM # Nm ##
+n2 # n2 # n2 # n2 # dotslow # nm # nM # nM # nm
+} right]</annotation>
+ </semantics>
+</math>


### PR DESCRIPTION
Adds the mirror edgemode described in #527 with an example showing how it extends an image. This is now used by backdrop-filter as per the resolution in #374.