### PR TITLE
[css-masking-1][editorial] Fixed typos in example

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -1262,15 +1262,15 @@ The 'mask-type' property allows the author of the <a element>mask</a> element to
     In the next example the computed value of 'mask-mode' is ''mask-mode/alpha'' and overrides the preference on the <a element>mask</a> element that is computed to ''mask-type/luminance''. The <a>mask layer image</a> is used as an alpha mask.
 
     <pre><code highlight=html>
-        lt;svg>
+        &lt;svg>
          &lt;mask style="mask-type: luminance;" id="mask2">
            ...
          &lt;/mask>
-        lt;/svg>
+        &lt;/svg>
 
-        lt;p style="mask-image: url(#mask2); mask-mode: alpha;">
+        &lt;p style="mask-image: url(#mask2); mask-mode: alpha;">
          This is the masked content.
-        lt;/p>
+        &lt;/p>
     </code></pre>
 </div>
 


### PR DESCRIPTION
This fixes https://github.com/w3c/csswg-drafts/issues/10456.

Sebastian