### PR TITLE
[compositing-2] Fix spurious / in <img>

### DIFF
--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -157,7 +157,7 @@ Note: Applying a blendmode other than <a value>normal</a> to the element must es
 ... will produce the following result:
 </p>
 <div class="figure">
-<img alt="example of an image of duck with the lime color of the document" src="examples/ducky_normal.png" style="width:30%"/>
+<img alt="example of an image of duck with the lime color of the document" src="examples/ducky_normal.png" style="width:30%">
 <p class="caption">
 Partially transparent image on a lime backdrop</p>
 </div>
@@ -170,7 +170,7 @@ img { mix-blend-mode: multiply; }
 ... the output will be the image blending with the lime background of the &lt;body> element.
 </p>
 <div class="figure">
-<img alt="example of an image of duck blending with the lime color of the document" src="examples/ducky_multiply.png" style="width:30%"/>
+<img alt="example of an image of duck blending with the lime color of the document" src="examples/ducky_multiply.png" style="width:30%">
 <p class="caption">
 Blending of a transparent image on a lime backdrop.
 </p>
@@ -194,7 +194,7 @@ circle { mix-blend-mode: screen; }
 ... the output will be blending of the 3 circles. Each circle is rendered from bottom to top. Where the elements overlap, the blend mode produces a change in color.
 </p>
 <div class="figure">
-<img alt="example of 3 circles blending with a screen blend mode" src="examples/screen_example.svg" style="width:30%"/>
+<img alt="example of 3 circles blending with a screen blend mode" src="examples/screen_example.svg" style="width:30%">
 <p class="caption">
 Example of 3 circles blending with a screen blend mode
 </p>
@@ -219,7 +219,7 @@ img { mix-blend-mode: difference; }
 ... the 'opacity' on the &lt;div> element is causing the creation of a stacking context. This causes the creation of a new group so the image doesn't blend with the color of the &lt;body>.
 </p>
 <div class="figure">
-<img alt="example of an image of duck blending with the lime color of the document" src="examples/ducky_difference.png" style="width:30%"/>
+<img alt="example of an image of duck blending with the lime color of the document" src="examples/ducky_difference.png" style="width:30%">
 <p class="caption">
 Example of blending within a stacking context.</p>
 </div>
@@ -251,7 +251,7 @@ p {
 </pre>
 
 <div class="figure">
-<img alt="example of text that has an overlay blend on top of a texture" src="examples/overlay_text.png" style="width:75%"/>
+<img alt="example of text that has an overlay blend on top of a texture" src="examples/overlay_text.png" style="width:75%">
 <p class="caption">
 Text with a blend overlay on top of an image.
 </p>
@@ -331,7 +331,7 @@ div {
 }
 </pre>
 <div class="figure">
-<img alt="example of div that has an image of a duck and a gradient that is blending" src="examples/ducky_background_blend.png" style="width:30%"/>
+<img alt="example of div that has an image of a duck and a gradient that is blending" src="examples/ducky_background_blend.png" style="width:30%">
 <p class="caption">
 Blending of 2 background images.
 </p>
@@ -473,7 +473,7 @@ Co = co / αo
 <h4 id="simplealphacompositingexamples">Examples of simple alpha compositing</h4>
 <div class="example">
 <div class="figure">
-<img src="examples/simple_box.svg" alt="Simple box showing alpha compositing"/>
+<img src="examples/simple_box.svg" alt="Simple box showing alpha compositing">
 <p class="caption"></p>
 </div>
 <p>
@@ -496,7 +496,7 @@ co = RGB(1,0,0)
 
 <div class="example">
 <div class="figure">
-<img src="examples/two_box.svg" alt="simple shape"/>
+<img src="examples/two_box.svg" alt="simple shape">
 <p class="caption"></p>
 </div>
 <p>
@@ -533,7 +533,7 @@ Co = RGB(0, 0, 1)
 
 <div class="example">
 <div class="figure">
-<img src="examples/two_box_transparency.svg" alt="interaction of a solid box with a transparent box on top"/>
+<img src="examples/two_box_transparency.svg" alt="interaction of a solid box with a transparent box on top">
 <p class="caption"></p>
 </div>
 <p>
@@ -569,7 +569,7 @@ Co = RGB(0.5, 0, 0.5)
 
 <div class="example">
 <div class="figure">
-<img src="examples/two_box_transparency_both.svg" alt="interaction of 2 transparent boxes"/>
+<img src="examples/two_box_transparency_both.svg" alt="interaction of 2 transparent boxes">
 <p class="caption"></p>
 </div>
 <p>
@@ -640,7 +640,7 @@ This means that the backdrop is the result of compositing all previous elements.
 <h3 id="backdropexamples">Examples of backdrop calculation</h3>
 <div class="example">
 <div class="figure">
-<img src="examples/simple_backdrop.svg" alt="example of a simple backdrop calculation"/>
+<img src="examples/simple_backdrop.svg" alt="example of a simple backdrop calculation">
 <p class="caption"></p>
 </div>
 <p>
@@ -650,7 +650,7 @@ The dotted line shows the area that is examined during compositing of the blue s
 </div>
 <div class="example">
 <div class="figure">
-<img src="examples/simple_backdrop_alpha.svg" alt="example of a backdrop with alpha"/>
+<img src="examples/simple_backdrop_alpha.svg" alt="example of a backdrop with alpha">
 <p class="caption"></p>
 </div>
 <p>
@@ -709,7 +709,7 @@ In a knockout group, each individual element shall be composited with the initia
 When calculating the <a>backdrop</a> for an element inside a knockout group, the elements of the group are ignored. Instead, only the elements that are behind the knockout group are included in the backdrop.
 </p>
 <div class="example">
-<p style="text-align:center"><img src="examples/knockout.png" alt="example of a knockout group"/></p>
+<p style="text-align:center"><img src="examples/knockout.png" alt="example of a knockout group"></p>
 </div>
 <p>
 The above example demonstrates two versions of a group containing three squares (red, green, blue) that are 50% opaque. The group is composited over a grey striped background.<br>
@@ -751,7 +751,7 @@ The four regions are:
 Note: Destination is synonymous with backdrop. The term destination is used in this section as this is considered the standard when working with Porter Duff compositing. Additionally, the compositing operators use ''destination'' in their names.
 
 <div class="figure">
-<p style="text-align:center"><img src="examples/PD_regions.svg" alt="overview of the regions affected by porter duff"/></p>
+<p style="text-align:center"><img src="examples/PD_regions.svg" alt="overview of the regions affected by porter duff"></p>
 <p class="caption"></p>
 </div>
 The contribution from each region to the final pixel color is defined by the coverage of the shape at that pixel, and the operator in use.
@@ -829,7 +829,7 @@ Where:
 With the <dfn>clear</dfn> compositing operator, no regions are enabled.
 
 <div class="figure">
-<img src="examples/PD_clr.svg" alt="example of porter duff clear"/>
+<img src="examples/PD_clr.svg" alt="example of porter duff clear">
 <p class="caption"></p>
 </div>
 <pre>
@@ -840,7 +840,7 @@ With the <dfn>clear</dfn> compositing operator, no regions are enabled.
 <h4 id="porterduffcompositingoperators_src">Copy</h4>
 With the <dfn>copy</dfn> compositing operator, only the source will be present.
 <div class="figure">
-<img src="examples/PD_src.svg" alt="example of porter duff copy"/>
+<img src="examples/PD_src.svg" alt="example of porter duff copy">
 <p class="caption"></p>
 </div>
 <pre>
@@ -854,7 +854,7 @@ With the <dfn>copy</dfn> compositing operator, only the source will be present.
 With the <dfn>destination</dfn> compositing operator, only the destination will be present.
 
 <div class="figure">
-<img src="examples/PD_dst.svg" alt="example of porter duff destination"/>
+<img src="examples/PD_dst.svg" alt="example of porter duff destination">
 <p class="caption"></p>
 </div>
 <pre>
@@ -868,7 +868,7 @@ With the <dfn>destination</dfn> compositing operator, only the destination will 
 With the <dfn>source-over</dfn> compositing operator, the source is placed over the destination.
 
 <div class="figure">
-<img src="examples/PD_src-over.svg" alt="example of porter duff source over"/>
+<img src="examples/PD_src-over.svg" alt="example of porter duff source over">
 <p class="caption"></p>
 </div>
 <pre>
@@ -881,7 +881,7 @@ With the <dfn>source-over</dfn> compositing operator, the source is placed over 
 With the <dfn>destination-over</dfn> compositing operator, Destination is placed over the source.
 
 <div class="figure">
-<img src="examples/PD_dst-over.svg" alt="example of porter duff destination over"/>
+<img src="examples/PD_dst-over.svg" alt="example of porter duff destination over">
 <p class="caption"></p>
 </div>
 <pre>
@@ -895,7 +895,7 @@ With the <dfn>destination-over</dfn> compositing operator, Destination is placed
 With the <dfn>source-in</dfn> compositing operator, the parts of the source that overlap with the desitnation are placed.
 
 <div class="figure">
-<img src="examples/PD_src-in.svg" alt="example of porter duff source in"/>
+<img src="examples/PD_src-in.svg" alt="example of porter duff source in">
 <p class="caption"></p>
 </div>
 <pre>
@@ -908,7 +908,7 @@ With the <dfn>source-in</dfn> compositing operator, the parts of the source that
 With the <dfn>destination-in</dfn> compositing operator, the parts of the destination that overlap with the source are placed.
 
 <div class="figure">
-<img src="examples/PD_dst-in.svg" alt="example of porter duff destination in "/>
+<img src="examples/PD_dst-in.svg" alt="example of porter duff destination in ">
 <p class="caption"></p>
 </div>
 <pre>
@@ -922,7 +922,7 @@ With the <dfn>destination-in</dfn> compositing operator, the parts of the destin
 With the <dfn>source-out</dfn> compositing operator, the parts of the source that fall outside of the destination are placed.
 
 <div class="figure">
-<img src="examples/PD_src-out.svg" alt="example of porter duff source out"/>
+<img src="examples/PD_src-out.svg" alt="example of porter duff source out">
 <p class="caption"></p>
 </div>
 <pre>
@@ -936,7 +936,7 @@ With the <dfn>source-out</dfn> compositing operator, the parts of the source tha
 With the <dfn>destination-out</dfn> compositing operator, the parts of the destination that fall outside of the source are placed.
 
 <div class="figure">
-<img src="examples/PD_dst-out.svg" alt="example of porter duff destination out"/>
+<img src="examples/PD_dst-out.svg" alt="example of porter duff destination out">
 <p class="caption"></p>
 </div>
 <pre>
@@ -950,7 +950,7 @@ With the <dfn>destination-out</dfn> compositing operator, the parts of the desti
 With the <dfn>source-atop</dfn> compositing operator, the parts of the source which overlap the destination replace the destination. The destination is placed everywhere else.
 
 <div class="figure">
-<img src="examples/PD_src-atop.svg" alt="example of porter duff source atop"/>
+<img src="examples/PD_src-atop.svg" alt="example of porter duff source atop">
 <p class="caption"></p>
 </div>
 <pre>
@@ -964,7 +964,7 @@ With the <dfn>source-atop</dfn> compositing operator, the parts of the source wh
 With the <dfn>destination-atop</dfn> compositing operator, the parts of the destination which overlaps the source replace the source. The source is placed everywhere else.
 
 <div class="figure">
-<img src="examples/PD_dst-atop.svg" alt="example of porter duff destination atop"/>
+<img src="examples/PD_dst-atop.svg" alt="example of porter duff destination atop">
 <p class="caption"></p>
 </div>
 <pre>
@@ -978,7 +978,7 @@ With the <dfn>destination-atop</dfn> compositing operator, the parts of the dest
 With the <dfn>xor</dfn> compositing operator, the non-overlapping regions of source and destination are combined.
 
 <div class="figure">
-<img src="examples/PD_xor.svg" alt="example of porter duff xor"/>
+<img src="examples/PD_xor.svg" alt="example of porter duff xor">
 <p class="caption"></p>
 </div>
 <pre>
@@ -1093,7 +1093,7 @@ This means, that for every element within the group, the backdrop for the compos
 In the example below, the elements within the group (the circle and the square) are composited using the [=source-atop=] operator, with only the hexagon.
 This has the effect of "knocking out" the circle, where it is overlapped by the square.<br>
 Additionally, because the source-atop Porter Duff operator is used, the source shape (either the square or the circle) is only placed where the backdrop exists (the backdrop being the hexagon for both compositing operations within the group).
-<div class="example"><img src="examples/pd-knockout.png" alt="example of knockout with porter duff"/></div>
+<div class="example"><img src="examples/pd-knockout.png" alt="example of knockout with porter duff"></div>
 </p>
 -->
 <!--
@@ -1103,7 +1103,7 @@ When compositing, the areas of the composite that may be modified by the composi
 This is known as "clip to self" in some graphics libraries.
 The alternative is to not clip the compositing operation at all. The results can be seen in the figure below.
 Some of the Porter Duff operators are unchanged, because they normally have no effect outside the source region. The changes can be seen in the clear, source, source-in, destination-in, source-out and destination-atop.
-<div class="figure"><img src="examples/clip-to-self.png" alt="example of clip to self with porter duff"/></div>
+<div class="figure"><img src="examples/clip-to-self.png" alt="example of clip to self with porter duff"></div>
 </p>
 -->
 <h2 id="blending">Blending</h2>
@@ -1151,7 +1151,7 @@ with:
 
 <div class="example">
 <div class="figure">
- <img src="examples/blend_background_opacity.svg" alt="example of blending with opacity"/>
+ <img src="examples/blend_background_opacity.svg" alt="example of blending with opacity">
  <p class="caption"></p>
 </div>
 <p>
@@ -1189,7 +1189,7 @@ This is the default attribute which specifies no blending. The blending formula 
     B(Cb, Cs) = Cs
 </pre>
 <div class="figure">
-<img src="examples/normal.png" alt="example of normal blending"/>
+<img src="examples/normal.png" alt="example of normal blending">
  <p class="caption"></p>
 </div>
 
@@ -1204,7 +1204,7 @@ The resultant color is always at least as dark as either the source or destinati
 </pre>
 </p>
 <div class="figure">
-<img src="examples/multiply.png" alt="example of multiply blending"/>
+<img src="examples/multiply.png" alt="example of multiply blending">
  <p class="caption"></p>
 </div>
 
@@ -1220,7 +1220,7 @@ The result color is always at least as light as either of the two constituent co
 </pre>
 </p>
 <div class="figure">
-<img src="examples/screen.png" alt="example of screen blending"/>
+<img src="examples/screen.png" alt="example of screen blending">
  <p class="caption"></p>
 </div>
 
@@ -1237,7 +1237,7 @@ Source colors overlay the <a>backdrop</a> while preserving its highlights and sh
 Overlay is the inverse of the <a value>hard-light</a> blend mode. See the definition of <a value>hard-light</a> for the formula.
 
 <div class="figure">
-<img src="examples/overlay.png" alt="example of overlay blending"/>
+<img src="examples/overlay.png" alt="example of overlay blending">
  <p class="caption"></p>
 </div>
 
@@ -1251,7 +1251,7 @@ The <a>backdrop</a> is replaced with the source where the source is darker; othe
     B(Cb, Cs) = min(Cb, Cs)
 </pre>
 <div class="figure">
-<img src="examples/darken.png" alt="example of darken blending"/>
+<img src="examples/darken.png" alt="example of darken blending">
  <p class="caption"></p>
 </div>
 
@@ -1268,7 +1268,7 @@ The <a>backdrop</a> is replaced with the source where the source is lighter; oth
 Note: The result must be rounded down if it exceeds the range.
 
 <div class="figure">
-<img src="examples/lighten.png" alt="example of lighten blending"/>
+<img src="examples/lighten.png" alt="example of lighten blending">
  <p class="caption"></p>
 </div>
 
@@ -1286,7 +1286,7 @@ Brightens the <a>backdrop</a> color to reflect the source color. Painting with b
 </pre>
 
 <div class="figure">
-  <img src="examples/colordodge.png" alt="example of color dodge blending"/>
+  <img src="examples/colordodge.png" alt="example of color dodge blending">
   <p class="caption"></p>
 </div>
 
@@ -1304,7 +1304,7 @@ Darkens the <a>backdrop</a> color to reflect the source color. Painting with whi
 </pre>
 
 <div class="figure">
-  <img src="examples/colorburn.png" alt="example of color burn blending"/>
+  <img src="examples/colorburn.png" alt="example of color burn blending">
   <p class="caption"></p>
 </div>
 
@@ -1322,7 +1322,7 @@ Multiplies or screens the colors, depending on the source color value. The effec
 See the definition of <a value>multiply</a> and <a value>screen</a> for their formulas.
 
 <div class="figure">
-  <img src="examples/hardlight.png" alt="example of hard light blending"/>
+  <img src="examples/hardlight.png" alt="example of hard light blending">
   <p class="caption"></p>
 </div>
 
@@ -1343,7 +1343,7 @@ with
 </pre>
 
 <div class="figure">
-  <img src="examples/softlight.png" alt="example of soft light blending"/>
+  <img src="examples/softlight.png" alt="example of soft light blending">
   <p class="caption"></p>
 </div>
 
@@ -1358,7 +1358,7 @@ Painting with white inverts the <a>backdrop</a> color; painting with black produ
 </pre>
 </p>
 <div class="figure">
-  <img src="examples/difference.png" alt="example of difference blending"/>
+  <img src="examples/difference.png" alt="example of difference blending">
   <p class="caption"></p>
 </div>
 
@@ -1371,7 +1371,7 @@ Produces an effect similar to that of the Difference mode but lower in contrast.
 </pre>
 </p>
 <div class="figure">
-  <img src="examples/exclusion.png" alt="example of exclusion blending"/>
+  <img src="examples/exclusion.png" alt="example of exclusion blending">
   <p class="caption"></p>
 </div>
 
@@ -1433,7 +1433,7 @@ Creates a color with the hue of the source color and the saturation and luminosi
 	B(Cb, Cs) = SetLum(SetSat(Cs, Sat(Cb)), Lum(Cb))
 </pre>
 <div class="figure">
-  <img src="examples/hue.png" alt="example of hue blending"/>
+  <img src="examples/hue.png" alt="example of hue blending">
   <p class="caption"></p>
 </div>
 
@@ -1445,7 +1445,7 @@ Creates a color with the saturation of the source color and the hue and luminosi
 	B(Cb, Cs) = SetLum(SetSat(Cb, Sat(Cs)), Lum(Cb))
 </pre>
 <div class="figure">
-  <img src="examples/saturation.png" alt="example of saturation blending"/>
+  <img src="examples/saturation.png" alt="example of saturation blending">
   <p class="caption"></p>
 </div>
 
@@ -1457,7 +1457,7 @@ Creates a color with the hue and saturation of the source color and the luminosi
 	B(Cb, Cs) = SetLum(Cs, Lum(Cb))
 </pre>
 <div class="figure">
-  <img src="examples/color.png" alt="example of color blending"/>
+  <img src="examples/color.png" alt="example of color blending">
   <p class="caption"></p>
 </div>
 
@@ -1468,7 +1468,7 @@ Creates a color with the luminosity of the source color and the hue and saturati
 	B(Cb, Cs) = SetLum(Cb, Lum(Cs))
 </pre>
 <div class="figure">
-  <img src="examples/luminosity.png" alt="example of luminosity blending"/>
+  <img src="examples/luminosity.png" alt="example of luminosity blending">
   <p class="caption"></p>
 </div>
 
@@ -1484,7 +1484,7 @@ In the normal group, the elements within the group are composited onto the initi
 In both instances, the result of the group composite is composited onto the land and sky using the normal mix-blend-mode (the default mix-blend-mode applied to the group).
 
   <div class="figure">
-  <img src="examples/isolate_blend_example.png" alt="example of isolated group blending"/>
+  <img src="examples/isolate_blend_example.png" alt="example of isolated group blending">
   <p class="caption"></p>
 </div>
 


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec compositing-2\Overview.bs
```

Throws errors:
```
LINE 160:1: Spurious / in <img>.  
LINE 173:1: Spurious / in <img>.  
LINE 197:1: Spurious / in <img>.  
LINE 222:1: Spurious / in <img>.  
LINE 254:1: Spurious / in <img>.  
LINE 334:1: Spurious / in <img>.  
LINE 476:1: Spurious / in <img>.  
LINE 499:1: Spurious / in <img>.  
LINE 536:1: Spurious / in <img>.  
LINE 572:1: Spurious / in <img>.  
LINE 643:1: Spurious / in <img>.  
LINE 653:1: Spurious / in <img>.  
LINE 754:30: Spurious / in <img>. 
LINE 832:1: Spurious / in <img>.  
LINE 843:1: Spurious / in <img>.  
LINE 857:1: Spurious / in <img>.  
LINE 871:1: Spurious / in <img>.  
LINE 884:1: Spurious / in <img>.  
LINE 898:1: Spurious / in <img>.  
LINE 911:1: Spurious / in <img>.  
LINE 925:1: Spurious / in <img>.  
LINE 939:1: Spurious / in <img>.  
LINE 953:1: Spurious / in <img>.  
LINE 967:1: Spurious / in <img>.  
LINE 981:1: Spurious / in <img>.  
LINE 1154:2: Spurious / in <img>. 
LINE 1192:1: Spurious / in <img>. 
LINE 1207:1: Spurious / in <img>. 
LINE 1223:1: Spurious / in <img>. 
LINE 1240:1: Spurious / in <img>. 
LINE 1254:1: Spurious / in <img>. 
LINE 1271:1: Spurious / in <img>. 
LINE 1289:3: Spurious / in <img>. 
LINE 1307:3: Spurious / in <img>. 
LINE 1325:3: Spurious / in <img>. 
LINE 1346:3: Spurious / in <img>. 
LINE 1361:3: Spurious / in <img>. 
LINE 1374:3: Spurious / in <img>. 
LINE 1436:3: Spurious / in <img>. 
LINE 1448:3: Spurious / in <img>. 
LINE 1460:3: Spurious / in <img>. 
LINE 1471:3: Spurious / in <img>. 
LINE 1487:3: Spurious / in <img>. 
```