### PR TITLE
[filter-effects-2] Fix spurious / in <img>

### DIFF
--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -226,9 +226,9 @@ performance breakdown. Clearly, this is not a scalable approach.
    the Backdrop Root is defined - this example is intended to illustrate why a
    Backdrop Root is formed by elements containing filters.</p>
 <div class="figure">
-  <img alt="ALT TEXT HERE" src="examples/step1.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/step1.png" style="width:30%">
   <p class="caption"><b>Step 1.</b> "Box" is rendered, but filters are not yet applied.</p>
-  <img alt="ALT TEXT HERE" src="examples/step2.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/step2.png" style="width:30%">
   <p class="caption"><b>Step 2.</b> "Dialog" is about to be rendered, but it has
     backdrop-filter applied. Since, for this example, the backdrop-filter "sees"
     all the way to the root, the "Box" element needs to be temporarily
@@ -237,22 +237,22 @@ performance breakdown. Clearly, this is not a scalable approach.
     atomicity of the Stacking Context created by "Box" is broken. This is also
     where the performance penalty applies - the GPU draw work that is
     performed here will end up being done twice.</p>
-  <img alt="ALT TEXT HERE" src="examples/step3.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/step3.png" style="width:30%">
   <p class="caption"><b>Step 3.</b> Start painting the "Dialog" element by
     reading back its backdrop image, applying the "backdrop-filter: blur(2px)"
     filter, and cropping those results to the border box of "Dialog". (The
     dotted black border has been added here for clarity: this is the border box
     for the "Dialog" element.)</p>
-  <img alt="ALT TEXT HERE" src="examples/step4.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/step4.png" style="width:30%">
   <p class="caption"><b>Step 4.</b> Now that the backdrop-filtered contents have
     been read back and filtered, discard the previously "completed" Box element
     and go back to the unfiltered version. Note that you can now see the black
     text at the bottom bleeding through the white, blurred version inside
     "Dialog".</p>
-  <img alt="ALT TEXT HERE" src="examples/step5.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/step5.png" style="width:30%">
   <p class="caption"><b>Step 5.</b> Draw the contents of the "Dialog" element -
     the <b>blue</b> border.</p>
-  <img alt="ALT TEXT HERE" src="examples/step6.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/step6.png" style="width:30%">
   <p class="caption"><b>Step 6.</b> Complete the Stacking Context formed by the
     "Box" element - apply the "filter: invert(1)" to "Box" and all of its
     contents, including the now-completed "Dialog" element. Note that the area
@@ -272,9 +272,9 @@ performance breakdown. Clearly, this is not a scalable approach.
   Backdrop Root is defined - this example is intended to illustrate why a
   Backdrop Root is formed by elements containing opacity less than 1.</p></p>
 <div class="figure">
-  <img alt="ALT TEXT HERE" src="examples/opacity.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/opacity.png" style="width:30%">
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <img alt="ALT TEXT HERE" src="examples/opacity_correct.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/opacity_correct.png" style="width:30%">
   <p class="caption">The left image is the final result of rendering, assuming
   the Backdrop Root includes everything on the page. Note that the blurred
   region inside the blue border is very faint. It is rendered at 0.25 opacity
@@ -297,9 +297,9 @@ performance breakdown. Clearly, this is not a scalable approach.
   intended to illustrate why a Backdrop Root is formed by elements containing
   masks.</p>
 <div class="figure">
-  <img alt="ALT TEXT HERE" src="examples/mask.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/mask.png" style="width:30%">
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <img alt="ALT TEXT HERE" src="examples/mask_correct.png" style="width:30%"/>
+  <img alt="ALT TEXT HERE" src="examples/mask_correct.png" style="width:30%">
   <p class="caption">The left image is the final result of rendering, assuming
   the Backdrop Root includes everything on the page. Note that the gradient
   applied to the blurred region inside the blue border (but not the border


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec filter-effects-2\Overview.bs
```

Throws errors:
```
LINE 229:3: Spurious / in <img>.
LINE 231:3: Spurious / in <img>.
LINE 240:3: Spurious / in <img>.
LINE 246:3: Spurious / in <img>.
LINE 252:3: Spurious / in <img>.
LINE 255:3: Spurious / in <img>.
LINE 275:3: Spurious / in <img>.
LINE 277:3: Spurious / in <img>.
LINE 300:3: Spurious / in <img>.
LINE 302:3: Spurious / in <img>.
```