### PR TITLE
[filter-effects-2] Fix spec version in link

### DIFF
--- a/filter-effects-2/Overview.bs
+++ b/filter-effects-2/Overview.bs
@@ -47,7 +47,7 @@ Inherited: no
 Percentages: n/a
 Computed value: as specified
 Media: visual
-Animation type: see prose in [[filter-effects#animation-of-filters]].
+Animation type: see prose in [[filter-effects-1#animation-of-filters]].
 </pre>
 
 If the value of the 'backdrop-filter' property is ''backdrop-filter/none'' then there is no
@@ -342,7 +342,7 @@ The current definition of mix-blend-mode <a href="https://www.w3.org/TR/composit
 
 <h2 id="priv-sec">Privacy and Security Considerations</h2>
 
-All of the same privacy and security concerns exist for backdrop-filter as do for "standard" filters. See [[filter-effects#tainted-filter-primitives]] for more details.
+All of the same privacy and security concerns exist for backdrop-filter as do for "standard" filters. See [[filter-effects-1#tainted-filter-primitives]] for more details.
 
 <h2 class=no-num id='acknowledgments'>Acknowledgments</h2>
 


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec filter-effects-2\Overview.bs
```

Throws errors:
```
LINE ~41: Section autolink [[filter-effects#animation-of-filters]] attempts to link to unversioned spec name 'filter-effects', but that spec is versioned as 'filter-effects-1' or 'filter-effects-2'. Please choose a versioned spec name.
LINE ~345: Section autolink [[filter-effects#tainted-filter-primitives]] attempts to link to unversioned spec name 'filter-effects', but that spec is versioned as 'filter-effects-1' or 'filter-effects-2'. Please choose a versioned spec name.
```

Choose spec version.