### PR TITLE
[filter-effects] Fix code example

### DIFF
--- a/filter-effects/Overview.bs
+++ b/filter-effects/Overview.bs
@@ -723,17 +723,17 @@ If a <a element>filter</a> element has no filter primitive tree then the element
 
 <div class=example>
     An example of multiple filter primitive trees:
-    <pre><code highlight=svg>
-        &lt;filter id="filter">
-          &lt-- The first filter primitive tree. Ignored for filter process. -->
-          &lt;feColorMatrix type="hueRotate" values="45"/>
-          &lt;feOffset dx="10" dy="10"/>
-          &lt;feGaussianBlur stdDeviation="3"/>
-          &lt-- The primary filter primitive tree. -->
-          &lt;feFlood flood-color="green" result="flood"/>
-          &lt;feComposite operator="in" in="SourceAlpha" in2="flood"/>
-        &lt;/filter>
-    </code></pre>
+    <xmp class=lang-markup>
+        <filter id="filter">
+          <!-- The first filter primitive tree. Ignored for filter process. -->
+          <feColorMatrix type="hueRotate" values="45"/>
+          <feOffset dx="10" dy="10"/>
+          <feGaussianBlur stdDeviation="3"/>
+          <!-- The primary filter primitive tree. -->
+          <feFlood flood-color="green" result="flood"/>
+          <feComposite operator="in" in="SourceAlpha" in2="flood"/>
+        </filter>
+   </xmp>
 
     The above filter has 2 filter primitive trees with the filter primitives:
     1. <a element>feColorMatrix</a>, <a element>feOffset</a> and <a element>feGaussianBlur</a> (with <a element>feGaussianBlur</a> being the root filter primitive of the tree) as well as

--- a/filter-effects/Overview.bs
+++ b/filter-effects/Overview.bs
@@ -723,17 +723,17 @@ If a <a element>filter</a> element has no filter primitive tree then the element
 
 <div class=example>
     An example of multiple filter primitive trees:
-    <xmp class=lang-markup>
-        <filter id="filter">
-          <!-- The first filter primitive tree. Ignored for filter process. -->
-          <feColorMatrix type="hueRotate" values="45"/>
-          <feOffset dx="10" dy="10"/>
-          <feGaussianBlur stdDeviation="3"/>
-          <!-- The primary filter primitive tree. -->
-          <feFlood flood-color="green" result="flood"/>
-          <feComposite operator="in" in="SourceAlpha" in2="flood"/>
-        </filter>
-   </xmp>
+    <pre><code highlight=svg>
+        &lt;filter id="filter">
+          &lt;!-- The first filter primitive tree. Ignored for filter process. -->
+          &lt;feColorMatrix type="hueRotate" values="45"/>
+          &lt;feOffset dx="10" dy="10"/>
+          &lt;feGaussianBlur stdDeviation="3"/>
+          &lt;!-- The primary filter primitive tree. -->
+          &lt;feFlood flood-color="green" result="flood"/>
+          &lt;feComposite operator="in" in="SourceAlpha" in2="flood"/>
+        &lt;/filter>
+    </code></pre>
 
     The above filter has 2 filter primitive trees with the filter primitives:
     1. <a element>feColorMatrix</a>, <a element>feOffset</a> and <a element>feGaussianBlur</a> (with <a element>feGaussianBlur</a> being the root filter primitive of the tree) as well as


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec filter-effects\Overview.bs
```

Throws errors:
```
LINE 728:11: Character reference '&lt' didn't end in ;.
LINE 732:11: Character reference '&lt' didn't end in ;.
```
HTML comment open tag is broken.