### PR TITLE
[motion-1] fix syntax definition for `ray()`

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -339,7 +339,7 @@ The ''ray()'' function defines an [=offset path=]
 as a straight line emerging from a point at some defined angle:
 
 <pre class=prod>
-<dfn>ray()</dfn> = ray( <<angle>> && <<ray-size>>? && contain? && [at <<position>>]? )
+<dfn>ray()</dfn> = ray( [ <<angle>> && <<ray-size>>? && contain? && [at <<position>>]? ] )
 
 <dfn>&lt;ray-size></dfn> = closest-side | closest-corner | farthest-side | farthest-corner | sides
 </pre>


### PR DESCRIPTION
See: https://github.com/csstree/csstree/issues/284#issuecomment-2347061047

> The ray() syntax is incorrect. That's a a && b && c && d expression:
> 
> ```
> ray( <angle> && <ray-size>? && contain? && [ at <position> ]? )
> ------------    -----------    --------    --------------------
>       a              b             c                d
> ```
> 
> Such a definition makes valid the following: `) contain ray( 200deg')`.