### PR TITLE
[css-masking-1][editorial] Clarified computed value descriptions to indicate list format for mask-* properties

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -442,7 +442,7 @@ Initial: none
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no
 Percentages: n/a
-Computed value: the keyword ''mask-image/none'', a computed <<image>>, or a computed <<url>>
+Computed value: list, each item the keyword ''mask-image/none'', a computed <<image>>, or a computed <<url>>
 Media: visual
 Animation type: discrete
 </pre>
@@ -494,7 +494,7 @@ Initial: match-source
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no
 Percentages: n/a
-Computed value: as specified
+Computed value: list, each item the keyword as specified
 Media: visual
 Animation type: discrete
 </pre>
@@ -555,7 +555,7 @@ Initial: repeat
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no
 Percentages: n/a
-Computed value: Consists of: two keywords, one per dimension
+Computed value: list, each item a pair of keywords, one per dimension
 Media: visual
 Animation type: discrete
 </pre>
@@ -592,7 +592,7 @@ Initial: 0% 0%
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no
 Percentages: refer to size of <a>mask painting area</a> <em>minus</em> size of <a>mask layer image</a>; see text 'background-position' [[!CSS3BG]]
-Computed value: Consisting of: two keywords representing the origin and two offsets from that origin, each given as an absolute length (if given a <<length>>), otherwise as a percentage.
+Computed value: list, each item consists of two keywords representing the origin and two offsets from that origin, each given as an absolute length (if given a <<length>>), otherwise as a percentage.
 Media: visual
 Animation type: repeatable list
 </pre>
@@ -629,7 +629,7 @@ Initial: border-box
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no
 Percentages: n/a
-Computed value: as specified
+Computed value: list, each item the keyword as specified
 Media: visual
 Animation type: discrete
 </pre>
@@ -679,7 +679,7 @@ Initial: border-box
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no
 Percentages: n/a
-Computed value: as specified
+Computed value: list, each item the keyword as specified
 Media: visual
 Animation type: discrete
 </pre>
@@ -726,7 +726,7 @@ Initial: auto
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no
 Percentages: n/a
-Computed value: as specified, but with lengths made absolute
+Computed value: list, each item as specified, but with lengths made absolute
 Media: visual
 Animation type: repeatable list
 </pre>
@@ -747,7 +747,7 @@ Initial: add
 Applies to: All elements. In SVG, it applies to <a>container elements</a> without the <a element>defs</a> element and all <a>graphics elements</a>
 Inherited: no
 Percentages: n/a
-Computed value: as specified
+Computed value: list, each item the keyword as specified
 Media: visual
 Animation type: discrete
 </pre>


### PR DESCRIPTION
The descriptions of the computed values of all `mask-*` properties were adjusted to indicate that they are lists. This was done in relation to CSS Backgrounds 3.

Note that the descriptions were explicitly _not_ adapted to fit the ones in CSS Backgrounds 3, for now, as that might need some clarification also on the CSS Backgrounds side.

This change fixes #604.

Sebastian