### PR TITLE
[css-masking-1][editorial] Negative mask-border-outset values are invalid

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -1070,7 +1070,7 @@ Note: For SVG elements without an associated layout box the 'border-width' is co
 
 <pre class=propdef>
 Name: mask-border-outset
-Value: [ <<length>> | <<number>> ]{1,4}
+Value: [ <<length [0,∞]>> | <<number [0,∞]>> ]{1,4}
 Initial: 0
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no


### PR DESCRIPTION
This PR encode the following in the syntax of `mask-border-outset`:

  > Negative values are not allowed for any of the [mask-border-outset](https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset) values.