### PR TITLE
[compositing-1][compositing-2] Added "Module" to spec title

### DIFF
--- a/compositing-1/Overview.bs
+++ b/compositing-1/Overview.bs
@@ -1,5 +1,5 @@
-<h1>Compositing and Blending Level 1</h1>
 <pre class='metadata'>
+Title: Compositing and Blending Module Level 1
 Status: ED
 Work Status: Refining
 ED: https://drafts.fxtf.org/compositing-1/
@@ -1511,12 +1511,12 @@ In both instances, the result of the group composite is composited onto the land
 
 <h2 id="privacy" class="no-num">
 Privacy Considerations</h2>
-  
+
   <p>No new privacy considerations have been reported on this specification.</p>
-  
+
 <h2 id="security" class="no-num">
 Security Considerations</h2>
-  
+
 It is important that the timing to the blending and compositing operations is independent of the source and destination pixel. Operations must be implemented in such a way that they always take the same amount of time regardless of the pixel values.</p>
 
 <div class="note">

--- a/compositing-2/Overview.bs
+++ b/compositing-2/Overview.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: Compositing and Blending Level 2
+Title: Compositing and Blending Module Level 2
 Group: fxtf
 Status: ED
 Work Status: Exploring


### PR DESCRIPTION
To unify the specification titles, I've added the word "Module" to the Compositing specs.
See also https://github.com/w3c/csswg-drafts/pull/12866 and https://github.com/w3c/csswg-drafts/pull/12879.

Sebastian