### PR TITLE
[css-masking-1] Defined serialization of 'mask-size'

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -760,6 +760,13 @@ See 'background-size' property [[!CSS3BG]] for the definitions of the property v
 
 See the section <a href="#layering">“Layering multiple mask layer images”</a> for how 'mask-size' interacts with other comma-separated mask properties to form each mask layer.
 
+<h4 id="mask-size-serialization">
+Serialization of 'mask-size' values</h4>
+
+    The [=specified value=] and [=computed value=] of the <<bg-size>> type
+    always serialize as two values, even when the second value is ''mask-size/auto'',
+    due to the [[cssom#serializing-css-values|shortest, most backwards-compatible serialization principle]].
+
 
 ## Compositing mask layers: the 'mask-composite' property ## {#the-mask-composite}
 
@@ -1493,6 +1500,7 @@ The following changes were made since the <a href="https://www.w3.org/TR/2014/CR
 * Clarify 'mask' shorthand behavior on appearance of one <<geometry-box>> and the ''no-clip'' keyword.
 * 'mask-mode' on a <a>mask layer image</a> that is a reference to a <a element>mask</a> element with a value of ''match-source'' should take the value of the 'mask-type' property on this <a element>mask</a> element.
 * Mapping of boxes for SVG elements with and without associated CSS layout box changed to match mapping in Fill and Stroke spec.
+* Defined serialization of 'mask-size' in [[#mask-size-serialization]]. (<a href="https://github.com/w3c/csswg-drafts/issues/7802">Issue 7802</a>)
 * Editorial changes.
 
 The following changes were made since the <a href="https://www.w3.org/TR/2014/WD-css-masking-1-20140522/">22 May 2014 Working Draft</a>.


### PR DESCRIPTION
This is one part of https://github.com/w3c/csswg-drafts/issues/7802#issuecomment-2770612154.
See https://github.com/w3c/csswg-drafts/pull/13053 for the other part.

Sebastian