### PR TITLE
Add auto-redirects to specs in CSSWG repository

### DIFF
--- a/compositing-1/index.html
+++ b/compositing-1/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/compositing-1/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/compositing-1/">https://drafts.csswg.org/compositing-1/</a></p>
+</body>

--- a/compositing-2/index.html
+++ b/compositing-2/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/compositing-2/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/compositing-2/">https://drafts.csswg.org/compositing-2/</a></p>
+</body>

--- a/css-masking-1/index.html
+++ b/css-masking-1/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/css-masking-1/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/css-masking-1/">https://drafts.csswg.org/css-masking-1/</a></p>
+</body>

--- a/css-shaders-1/index.html
+++ b/css-shaders-1/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/css-shaders-1/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/css-shaders-1/">https://drafts.csswg.org/css-shaders-1/</a></p>
+</body>

--- a/fill-stroke/index.html
+++ b/fill-stroke/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/fill-stroke/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/fill-stroke/">https://drafts.csswg.org/fill-stroke/</a></p>
+</body>

--- a/filter-effects-1/index.html
+++ b/filter-effects-1/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/filter-effects-1/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/filter-effects-1/">https://drafts.csswg.org/filter-effects-1/</a></p>
+</body>

--- a/filter-effects-2/index.html
+++ b/filter-effects-2/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/filter-effects-2/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/filter-effects-2/">https://drafts.csswg.org/filter-effects-2/</a></p>
+</body>

--- a/geometry/index.html
+++ b/geometry/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/geometry/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/geometry/">https://drafts.csswg.org/geometry/</a></p>
+</body>

--- a/matrix/index.html
+++ b/matrix/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/matrix/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/matrix/">https://drafts.csswg.org/matrix/</a></p>
+</body>

--- a/motion-1/index.html
+++ b/motion-1/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/motion-1/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/motion-1/">https://drafts.csswg.org/motion-1/</a></p>
+</body>

--- a/web-animations/index.html
+++ b/web-animations/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved to the CSSWG repository</title>
+</head>
+<body onload='(function() { location.href = "https://drafts.csswg.org/web-animations/" + location.hash; })()'>
+<p>Moved to <a href="https://drafts.csswg.org/web-animations/">https://drafts.csswg.org/web-animations/</a></p>
+</body>


### PR DESCRIPTION
Specifications moved to the CSSWG repository. A few sources still link to the previous URLs for the Editor's Drafts, including /TR documents (when they exist), the W3C API, browser-specs, Specref, and MDN.

Sources will be updated, but the redirects help make the transition seamless.

I had started doing that in:
  https://github.com/w3c/w3c.github.io/pull/135
... but that cannot work given that the specs were not served under:
  https://w3c.github.io/

Note: There may be a way to add proper 302 redirects to drafts.fxtf.org URLs, but I don't know how. Using HTML redirects as a fallback.